### PR TITLE
Add palette mask split mode

### DIFF
--- a/docs/superpowers/plans/2026-06-09-vulca-palette-mask.md
+++ b/docs/superpowers/plans/2026-06-09-vulca-palette-mask.md
@@ -1,0 +1,118 @@
+# Vulca Palette Mask Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first Vulca palette-mask split mode that asks an image provider such as NB2/Gemini for a color-coded ownership image, decodes it into editable layer masks, and writes the normal layer stack.
+
+**Architecture:** Add a focused `vulca.layers.palette_mask` module for prompt construction, provider call, RGB color decoding, and layer extraction. Wire it into existing `layers_split` CLI/MCP surfaces as `mode="palette"` while preserving the existing analyze-first layer planning flow.
+
+**Tech Stack:** Python 3.10+, Pillow, NumPy, existing Vulca provider registry, existing manifest writer, pytest.
+
+---
+
+### Task 1: Palette Mask Core
+
+**Files:**
+- Create: `src/vulca/layers/palette_mask.py`
+- Test: `tests/test_palette_mask.py`
+
+- [ ] **Step 1: Write failing decoder tests**
+
+Add tests for prompt content, exact-color decoding, nearest-color tolerance, and layer PNG extraction.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `python3 -m pytest tests/test_palette_mask.py -q`
+Expected: import failure for `vulca.layers.palette_mask`.
+
+- [ ] **Step 3: Implement palette mask module**
+
+Define:
+- `DEFAULT_PALETTE`
+- `build_palette_mask_prompt(layers, palette=None)`
+- `decode_palette_mask(mask_image, layers, palette=None, tolerance=48)`
+- `split_palette(image_path, layers, output_dir, provider="nb2", api_key="", palette=None, tolerance=48)`
+
+`split_palette` should call provider once with `raw_prompt=True`, decode the returned RGB image into per-layer masks, apply masks to the source image, write full-canvas RGBA PNGs, and write `manifest.json` with `split_mode="palette"`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python3 -m pytest tests/test_palette_mask.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit core**
+
+Run:
+```bash
+git add src/vulca/layers/palette_mask.py tests/test_palette_mask.py
+git commit -m "feat: add palette mask split core"
+```
+
+### Task 2: CLI and MCP Wiring
+
+**Files:**
+- Modify: `src/vulca/cli.py`
+- Modify: `src/vulca/mcp_server.py`
+- Modify: `src/vulca/layers/__init__.py`
+- Test: `tests/test_palette_mask.py`
+
+- [ ] **Step 1: Add failing surface tests**
+
+Extend tests to assert:
+- CLI help includes `palette`.
+- MCP `layers_split` docstring mentions `palette`.
+- `split_palette` is importable from `vulca.layers`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `python3 -m pytest tests/test_palette_mask.py -q`
+Expected: failures for missing CLI/MCP/export wiring.
+
+- [ ] **Step 3: Wire mode**
+
+Add `palette` to CLI choices and help. In CLI split handler, route `args.mode == "palette"` to `split_palette`. In MCP `layers_split`, add docstring text and route `mode == "palette"` to `split_palette`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `python3 -m pytest tests/test_palette_mask.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit wiring**
+
+Run:
+```bash
+git add src/vulca/cli.py src/vulca/mcp_server.py src/vulca/layers/__init__.py tests/test_palette_mask.py
+git commit -m "feat: expose palette mask split mode"
+```
+
+### Task 3: Local Smoke
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run: `python3 -m pytest tests/test_palette_mask.py tests/test_v012_split_vlm.py -q`
+Expected: pass.
+
+- [ ] **Step 2: Run mock provider smoke**
+
+Run a temporary script that creates a two-object source image, patches a mock provider to return a two-color palette mask, and confirms the output manifest/layers.
+
+- [ ] **Step 3: Run real Gemini/NB2 smoke if key exists**
+
+Check only whether `GEMINI_API_KEY` or `GOOGLE_API_KEY` is set. If present, run `split_palette(... provider="nb2")` against a tiny synthetic slide-like image. If absent, report the smoke as blocked without printing secrets.
+
+- [ ] **Step 4: Commit plan**
+
+Run:
+```bash
+git add docs/superpowers/plans/2026-06-09-vulca-palette-mask.md
+git commit -m "docs: plan palette mask split mode"
+```
+
+### Self-Review
+
+- Spec coverage: covers palette mask protocol, decoding, `layers_split(mode="palette")`, Redraw/PPT-compatible layers, and Gemini/NB2 smoke attempt.
+- Placeholder scan: no placeholders remain.
+- Type consistency: functions are consistently named `build_palette_mask_prompt`, `decode_palette_mask`, and `split_palette`.

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -181,8 +181,8 @@ def main(argv: list[str] | None = None) -> None:
     layers_split.add_argument("image", help="Path to image")
     layers_split.add_argument("--output", "-o", default="", help="Output directory")
     layers_split.add_argument("--mode", "-m", default="regenerate",
-                              choices=["regenerate", "extract", "sam", "vlm", "sam3"],
-                              help="Split mode: regenerate | extract | sam | vlm | sam3 (needs vulca[sam3] + GPU)")
+                              choices=["regenerate", "extract", "sam", "vlm", "palette", "sam3"],
+                              help="Split mode: regenerate | extract | sam | vlm | palette | sam3 (needs vulca[sam3] + GPU)")
     layers_split.add_argument("--provider", "-p", default="gemini", help="Image provider (regenerate mode)")
     layers_split.add_argument("--tradition", "-t", default="default", help="Cultural tradition")
     layers_split.add_argument(
@@ -1480,6 +1480,12 @@ def _cmd_layers(args: argparse.Namespace) -> None:
             results = loop.run_until_complete(
                 split_vlm(args.image, layers, output_dir=out_dir,
                           provider=args.provider)
+            )
+        elif args.mode == "palette":
+            from vulca.layers.palette_mask import split_palette
+            results = loop.run_until_complete(
+                split_palette(args.image, layers, output_dir=out_dir,
+                              provider=args.provider)
             )
         elif args.mode == "sam3":
             from vulca.layers.sam3 import sam3_split

--- a/src/vulca/layers/__init__.py
+++ b/src/vulca/layers/__init__.py
@@ -2,6 +2,7 @@
 from vulca.layers.types import LayerInfo, LayerResult, LayeredArtwork
 from vulca.layers.analyze import analyze_layers, parse_layer_response
 from vulca.layers.split import split_extract, split_regenerate, split_vlm, crop_layer, chromakey_white, chromakey_black
+from vulca.layers.palette_mask import split_palette, build_palette_mask_prompt, decode_palette_mask
 from vulca.layers.composite import composite_layers
 from vulca.layers.blend import blend_normal, blend_screen, blend_multiply, blend_overlay, blend_soft_light, blend_darken, blend_lighten, blend_color_dodge, blend_color_burn, blend_layers
 from vulca.layers.export import export_psd
@@ -40,7 +41,8 @@ from vulca.layers.manifest import load_manifest as load_artwork
 __all__ = [
     "LayerInfo", "LayerResult", "LayeredArtwork",
     "analyze_layers", "parse_layer_response",
-    "split_extract", "split_regenerate", "split_vlm",
+    "split_extract", "split_regenerate", "split_vlm", "split_palette",
+    "build_palette_mask_prompt", "decode_palette_mask",
     "crop_layer", "chromakey_white", "chromakey_black",
     "composite_layers",
     "blend_normal", "blend_screen", "blend_multiply",

--- a/src/vulca/layers/palette_mask.py
+++ b/src/vulca/layers/palette_mask.py
@@ -1,0 +1,236 @@
+"""Palette-coded visual task masks.
+
+This is the first Vision-Banana-style bridge in Vulca: ask an image provider
+to render a flat RGB ownership image, then decode those colors into normal
+Vulca RGBA layers.
+"""
+from __future__ import annotations
+
+import base64
+import colorsys
+import io
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from vulca.layers.coarse_bucket import is_background
+from vulca.layers.manifest import write_manifest
+from vulca.layers.mask import apply_mask_to_image
+from vulca.layers.types import LayerInfo, LayerResult
+
+DEFAULT_PALETTE: tuple[str, ...] = (
+    "#ff0000",
+    "#00ff00",
+    "#0000ff",
+    "#ffff00",
+    "#ff00ff",
+    "#00ffff",
+    "#ff8000",
+    "#8000ff",
+    "#0080ff",
+    "#80ff00",
+    "#ff0080",
+    "#00ff80",
+)
+BACKGROUND_COLOR = "#000000"
+
+
+def build_palette_mask_prompt(
+    layers: list[LayerInfo],
+    *,
+    palette: dict[str, str] | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Build a provider prompt and resolved layer-name -> hex palette map."""
+    resolved = _resolve_palette(layers, palette)
+    entries = "\n".join(
+        f"- {info.name}: {resolved[info.name]} = {info.description or info.name}"
+        for info in sorted(layers, key=lambda item: item.z_index, reverse=True)
+    )
+    prompt = (
+        "Create a pure flat RGB palette mask for the provided image.\n"
+        "Do not generate a normal image, realistic image, shaded image, or textured image.\n"
+        "Every output pixel must be one of the exact colors listed below.\n"
+        "Use hard boundaries. Do not use gradients, shadows, labels, text, anti-aliased outlines, or extra colors.\n"
+        "The output must match the input image dimensions and composition.\n\n"
+        "Palette ownership map:\n"
+        f"{entries}\n\n"
+        "If a pixel does not belong to a listed foreground target, use the background color."
+    )
+    return prompt, resolved
+
+
+def decode_palette_mask(
+    mask_image: Image.Image,
+    layers: list[LayerInfo],
+    *,
+    palette: dict[str, str] | None = None,
+    tolerance: int = 48,
+) -> dict[str, Image.Image]:
+    """Decode an RGB palette mask into per-layer grayscale masks.
+
+    Pixels are assigned to the nearest palette color when within `tolerance`.
+    Out-of-tolerance pixels fall back to the background layer when present.
+    """
+    if not layers:
+        return {}
+
+    resolved = _resolve_palette(layers, palette)
+    ordered = list(layers)
+    colors = np.array([_hex_to_rgb(resolved[info.name]) for info in ordered], dtype=np.float32)
+    rgb = np.array(mask_image.convert("RGB"), dtype=np.float32)
+
+    diff = rgb[:, :, None, :] - colors[None, None, :, :]
+    distances = np.sqrt(np.sum(diff * diff, axis=3))
+    nearest = np.argmin(distances, axis=2)
+    nearest_distance = np.min(distances, axis=2)
+    within = nearest_distance <= float(tolerance)
+
+    background_index = next(
+        (idx for idx, info in enumerate(ordered) if is_background(info.content_type)),
+        None,
+    )
+
+    masks: dict[str, Image.Image] = {}
+    for idx, info in enumerate(ordered):
+        mask = (nearest == idx) & within
+        if background_index is not None and idx == background_index:
+            mask = mask | ~within
+        masks[info.id] = Image.fromarray((mask.astype(np.uint8) * 255), mode="L")
+    return masks
+
+
+async def split_palette(
+    image_path: str,
+    layers: list[LayerInfo],
+    *,
+    output_dir: str,
+    provider: str = "nb2",
+    api_key: str = "",
+    palette: dict[str, str] | None = None,
+    tolerance: int = 48,
+) -> list[LayerResult]:
+    """Split an image into layers using a provider-generated palette mask."""
+    from vulca.providers import get_image_provider
+
+    source = Image.open(image_path).convert("RGB")
+    width, height = source.size
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    prompt, resolved_palette = build_palette_mask_prompt(layers, palette=palette)
+    ref_b64 = base64.b64encode(Path(image_path).read_bytes()).decode()
+    img_provider = get_image_provider(provider, api_key=api_key)
+    result = await img_provider.generate(
+        prompt,
+        reference_image_b64=ref_b64,
+        raw_prompt=True,
+        width=width,
+        height=height,
+    )
+    raw = base64.b64decode(result.image_b64)
+    if getattr(result, "mime", "") and "svg" in result.mime:
+        raise ValueError("palette mask provider returned SVG; expected raster image")
+
+    palette_img = Image.open(io.BytesIO(raw)).convert("RGB")
+    if palette_img.size != (width, height):
+        palette_img = palette_img.resize((width, height), Image.NEAREST)
+    palette_img.save(out_dir / "palette_mask.png")
+
+    masks = decode_palette_mask(
+        palette_img,
+        layers,
+        palette=resolved_palette,
+        tolerance=tolerance,
+    )
+
+    results: list[LayerResult] = []
+    warnings: list[str] = []
+    canvas_px = float(width * height) if width and height else 1.0
+    for info in sorted(layers, key=lambda item: item.z_index):
+        mask = masks.get(info.id) or Image.new("L", (width, height), 0)
+        mask_arr = np.array(mask)
+        visible_px = int((mask_arr > 127).sum())
+        info.area_pct = 100.0 * visible_px / canvas_px
+        info.quality_status = "detected" if visible_px else "missed"
+        info.dominant_colors = [resolved_palette[info.name]]
+        if not visible_px:
+            warnings.append(f"palette mask produced empty layer: {info.name}")
+        layer_img = apply_mask_to_image(source, mask)
+        out_path = out_dir / f"{info.name}.png"
+        layer_img.save(out_path)
+        results.append(LayerResult(info=info, image_path=str(out_path)))
+
+    write_manifest(
+        layers,
+        output_dir=output_dir,
+        width=width,
+        height=height,
+        source_image=image_path,
+        split_mode="palette",
+        generation_path="palette_mask.png",
+        partial=bool(warnings),
+        warnings=warnings,
+    )
+    return results
+
+
+def _resolve_palette(
+    layers: list[LayerInfo],
+    palette: dict[str, str] | None,
+) -> dict[str, str]:
+    supplied = palette or {}
+    resolved: dict[str, str] = {}
+    foreground_idx = 0
+    for info in sorted(layers, key=lambda item: item.z_index, reverse=True):
+        if info.name in supplied:
+            resolved[info.name] = _normalize_hex(supplied[info.name])
+            continue
+        if is_background(info.content_type):
+            resolved[info.name] = BACKGROUND_COLOR
+            continue
+        if foreground_idx < len(DEFAULT_PALETTE):
+            resolved[info.name] = DEFAULT_PALETTE[foreground_idx]
+        else:
+            resolved[info.name] = _generated_color(foreground_idx)
+        foreground_idx += 1
+    return resolved
+
+
+def _normalize_hex(value: str) -> str:
+    value = value.strip().lower()
+    if not value.startswith("#"):
+        value = "#" + value
+    if len(value) == 4:
+        value = "#" + "".join(ch * 2 for ch in value[1:])
+    if len(value) != 7:
+        raise ValueError(f"invalid palette color {value!r}; expected #RRGGBB")
+    _hex_to_rgb(value)
+    return value
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    value = _normalize_hex_no_validate(value)
+    return (
+        int(value[1:3], 16),
+        int(value[3:5], 16),
+        int(value[5:7], 16),
+    )
+
+
+def _normalize_hex_no_validate(value: str) -> str:
+    value = value.strip().lower()
+    if not value.startswith("#"):
+        value = "#" + value
+    if len(value) == 4:
+        value = "#" + "".join(ch * 2 for ch in value[1:])
+    if len(value) != 7:
+        raise ValueError(f"invalid palette color {value!r}; expected #RRGGBB")
+    int(value[1:], 16)
+    return value
+
+
+def _generated_color(index: int) -> str:
+    hue = (index * 0.61803398875) % 1.0
+    red, green, blue = colorsys.hsv_to_rgb(hue, 0.85, 1.0)
+    return f"#{int(red * 255):02x}{int(green * 255):02x}{int(blue * 255):02x}"

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -736,6 +736,7 @@ async def layers_split(
         image_path: Path to the image file.
         output_dir: Output directory (default: image parent/layers).
         mode: "regenerate" (img2img), "extract" (color-range), "vlm" (VLM masks),
+              "palette" (provider-generated color-coded ownership masks),
               "sam3" (SAM3, GPU), "orchestrated" (YOLO26 + Grounding DINO + SAM +
               SegFormer face-parsing; SOTA — requires plan_path).
         provider: Image provider for regenerate/vlm modes.
@@ -850,6 +851,12 @@ async def layers_split(
     elif mode == "vlm":
         from vulca.layers.split import split_vlm
         results = await split_vlm(
+            image_path, layers, output_dir=out,
+            provider=provider,
+        )
+    elif mode == "palette":
+        from vulca.layers.palette_mask import split_palette
+        results = await split_palette(
             image_path, layers, output_dir=out,
             provider=provider,
         )

--- a/tests/test_palette_mask.py
+++ b/tests/test_palette_mask.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+from PIL import Image
+
+from vulca.layers.types import LayerInfo
+
+
+def _layer(name: str, z: int, *, content_type: str = "subject") -> LayerInfo:
+    return LayerInfo(
+        name=name,
+        id=f"layer_{name}",
+        description=f"the {name} region",
+        z_index=z,
+        content_type=content_type,
+    )
+
+
+def _image_to_b64(img: Image.Image) -> str:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _source_image() -> Image.Image:
+    img = Image.new("RGB", (6, 4), (240, 240, 240))
+    pixels = img.load()
+    for y in range(4):
+        for x in range(3):
+            pixels[x, y] = (200, 80, 80)
+        for x in range(3, 6):
+            pixels[x, y] = (80, 120, 200)
+    return img
+
+
+def _palette_mask(*, fuzzy: bool = False) -> Image.Image:
+    img = Image.new("RGB", (6, 4), (0, 0, 0))
+    pixels = img.load()
+    left = (255, 0, 0) if not fuzzy else (248, 5, 3)
+    right = (0, 255, 0) if not fuzzy else (4, 247, 8)
+    for y in range(4):
+        for x in range(3):
+            pixels[x, y] = left
+        for x in range(3, 6):
+            pixels[x, y] = right
+    return img
+
+
+def _mock_provider(mask: Image.Image) -> MagicMock:
+    result = MagicMock()
+    result.image_b64 = _image_to_b64(mask)
+    result.mime = "image/png"
+    provider = MagicMock()
+    provider.generate = AsyncMock(return_value=result)
+    return provider
+
+
+def test_build_palette_mask_prompt_contains_contract_and_colors():
+    from vulca.layers.palette_mask import build_palette_mask_prompt
+
+    prompt, palette = build_palette_mask_prompt([
+        _layer("product", 2),
+        _layer("background", 0, content_type="background"),
+    ])
+
+    assert "pure flat RGB palette mask" in prompt
+    assert "Do not generate a normal image" in prompt
+    assert "product" in prompt
+    assert palette["product"] == "#ff0000"
+    assert palette["background"] == "#000000"
+
+
+def test_decode_palette_mask_exact_colors():
+    from vulca.layers.palette_mask import decode_palette_mask
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    masks = decode_palette_mask(
+        _palette_mask(),
+        [product, icon],
+        palette={"product": "#ff0000", "icon": "#00ff00"},
+    )
+
+    product_arr = np.array(masks[product.id])
+    icon_arr = np.array(masks[icon.id])
+    assert product_arr[:, :3].min() == 255
+    assert product_arr[:, 3:].max() == 0
+    assert icon_arr[:, :3].max() == 0
+    assert icon_arr[:, 3:].min() == 255
+
+
+def test_decode_palette_mask_nearest_color_tolerance():
+    from vulca.layers.palette_mask import decode_palette_mask
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    masks = decode_palette_mask(
+        _palette_mask(fuzzy=True),
+        [product, icon],
+        palette={"product": "#ff0000", "icon": "#00ff00"},
+        tolerance=24,
+    )
+
+    assert np.array(masks[product.id])[:, :3].min() == 255
+    assert np.array(masks[icon.id])[:, 3:].min() == 255
+
+
+def test_split_palette_calls_provider_once_and_writes_layers():
+    from vulca.layers.palette_mask import split_palette
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with patch("vulca.providers.get_image_provider", return_value=provider):
+            results = asyncio.run(
+                split_palette(
+                    str(source_path),
+                    [product, icon],
+                    output_dir=td,
+                    provider="nb2",
+                    palette={"product": "#ff0000", "icon": "#00ff00"},
+                )
+            )
+
+        assert provider.generate.call_count == 1
+        call = provider.generate.call_args
+        assert call.kwargs["raw_prompt"] is True
+        assert call.kwargs["reference_image_b64"]
+
+        by_name = {r.info.name: r for r in results}
+        product_img = Image.open(by_name["product"].image_path)
+        icon_img = Image.open(by_name["icon"].image_path)
+        assert product_img.mode == "RGBA"
+        assert icon_img.mode == "RGBA"
+        assert np.array(product_img)[:, :3, 3].min() == 255
+        assert np.array(product_img)[:, 3:, 3].max() == 0
+        assert np.array(icon_img)[:, :3, 3].max() == 0
+        assert np.array(icon_img)[:, 3:, 3].min() == 255
+
+        manifest = json.loads((Path(td) / "manifest.json").read_text())
+        assert manifest["split_mode"] == "palette"
+
+
+def test_split_palette_importable_from_layers():
+    from vulca.layers import split_palette
+
+    assert callable(split_palette)
+
+
+def test_cli_layers_split_help_mentions_palette():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "vulca.cli", "layers", "split", "--help"],
+        text=True,
+        capture_output=True,
+        check=True,
+        env=env,
+    )
+
+    assert "palette" in result.stdout
+
+
+def test_mcp_layers_split_docstring_mentions_palette():
+    from vulca.mcp_server import layers_split
+
+    assert "palette" in (layers_split.__doc__ or "")


### PR DESCRIPTION
## Summary
- Add `vulca.layers.palette_mask` for provider-generated RGB ownership masks and deterministic mask decoding.
- Expose `layers_split(mode=\"palette\")` through CLI and MCP, with `provider=\"nb2\"` support via the existing provider registry.
- Add focused tests for prompt contract, color decoding, split output, CLI/MCP surface, and export.

## Test Plan
- `PYTHONPATH=src python3 -m pytest tests/test_palette_mask.py tests/test_v012_split_vlm.py -q`
- Mock provider smoke: one palette-mask provider call produced `palette_mask.png`, decoded layer PNGs, and `manifest.json`.
- Real NB2/Gemini smoke: loaded `GEMINI_API_KEY` from macOS keychain, ran `split_palette(... provider=\"nb2\")` on a synthetic slide image, and produced `palette_mask.png`, `background.png`, `chart_block.png`, `product_block.png`, and `manifest.json`.

## Real Smoke Notes
- Output directory: `/tmp/vulca_palette_nb2_real_1781022453`
- Decoded areas: background 61.93%, chart_block 19.54%, product_block 18.53%; all detected.
- NB2 did not emit mathematically exact palette colors; it emitted many near-colors around black/red/green. The tolerance decoder handled this as intended.