### PR TITLE
Add debug artifacts for palette mask splits

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -1500,6 +1500,16 @@ def _cmd_layers(args: argparse.Namespace) -> None:
         for r in results:
             print(f"    [{r.info.z_index}] {r.info.name} -> {r.image_path}")
         print(f"    manifest.json -> {Path(out_dir) / 'manifest.json'}")
+        if getattr(args, "mode", None) == "palette":
+            for artifact_name in (
+                "palette_mask.png",
+                "palette_mask_quantized.png",
+                "decode_report.json",
+                "contact_sheet.png",
+            ):
+                artifact_path = Path(out_dir) / artifact_name
+                if artifact_path.exists():
+                    print(f"    {artifact_name} -> {artifact_path}")
         from vulca.layers.decompose_cases import (
             append_decompose_case,
             build_decompose_case,

--- a/src/vulca/layers/palette_mask.py
+++ b/src/vulca/layers/palette_mask.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import base64
 import colorsys
 import io
+import json
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageDraw, ImageOps
 
 from vulca.layers.coarse_bucket import is_background
 from vulca.layers.manifest import write_manifest
@@ -34,6 +36,31 @@ DEFAULT_PALETTE: tuple[str, ...] = (
     "#00ff80",
 )
 BACKGROUND_COLOR = "#000000"
+
+
+@dataclass
+class PaletteDecodeLayerReport:
+    layer_id: str
+    name: str
+    palette_color: str
+    pixel_count: int
+    area_pct: float
+    bbox: dict[str, int] | None
+    quality_status: str
+    unmatched_pct: float
+    warnings: list[str]
+
+
+@dataclass
+class PaletteDecodeReport:
+    width: int
+    height: int
+    tolerance: int
+    unmatched_pixel_count: int
+    unmatched_pct: float
+    background_layer_id: str | None
+    warnings: list[str]
+    layers: list[PaletteDecodeLayerReport]
 
 
 def build_palette_mask_prompt(
@@ -72,32 +99,184 @@ def decode_palette_mask(
     Pixels are assigned to the nearest palette color when within `tolerance`.
     Out-of-tolerance pixels fall back to the background layer when present.
     """
+    masks, _quantized, _report = quantize_palette_mask(
+        mask_image,
+        layers,
+        palette=palette,
+        tolerance=tolerance,
+    )
+    return masks
+
+
+def quantize_palette_mask(
+    mask_image: Image.Image,
+    layers: list[LayerInfo],
+    *,
+    palette: dict[str, str] | None = None,
+    tolerance: int = 48,
+) -> tuple[dict[str, Image.Image], Image.Image, PaletteDecodeReport]:
+    """Decode and re-render a palette mask with exact resolved palette colors."""
+    width, height = mask_image.size
     if not layers:
-        return {}
+        report = PaletteDecodeReport(
+            width=width,
+            height=height,
+            tolerance=tolerance,
+            unmatched_pixel_count=0,
+            unmatched_pct=0.0,
+            background_layer_id=None,
+            warnings=[],
+            layers=[],
+        )
+        return {}, Image.new("RGB", (width, height), BACKGROUND_COLOR), report
 
     resolved = _resolve_palette(layers, palette)
     ordered = list(layers)
-    colors = np.array([_hex_to_rgb(resolved[info.name]) for info in ordered], dtype=np.float32)
-    rgb = np.array(mask_image.convert("RGB"), dtype=np.float32)
+    colors_u8 = np.array([_hex_to_rgb(resolved[info.name]) for info in ordered], dtype=np.uint8)
+    colors = colors_u8.astype(np.float32)
+    rgb_u8 = np.array(mask_image.convert("RGB"), dtype=np.uint8)
+    rgb = rgb_u8.astype(np.float32)
 
-    diff = rgb[:, :, None, :] - colors[None, None, :, :]
-    distances = np.sqrt(np.sum(diff * diff, axis=3))
-    nearest = np.argmin(distances, axis=2)
-    nearest_distance = np.min(distances, axis=2)
-    within = nearest_distance <= float(tolerance)
+    nearest = np.zeros((height, width), dtype=np.intp)
+    nearest_distance_sq = np.full((height, width), np.inf, dtype=np.float32)
+    for idx, color in enumerate(colors):
+        diff = rgb - color
+        distance_sq = np.sum(diff * diff, axis=2)
+        closer = distance_sq < nearest_distance_sq
+        nearest[closer] = idx
+        nearest_distance_sq[closer] = distance_sq[closer]
+    within = nearest_distance_sq <= float(tolerance * tolerance)
 
     background_index = next(
         (idx for idx, info in enumerate(ordered) if is_background(info.content_type)),
         None,
     )
+    background_layer_id = ordered[background_index].id if background_index is not None else None
 
+    assigned = nearest.copy()
+    unmatched = ~within
+    if background_index is not None:
+        assigned[unmatched] = background_index
+        unmatched = np.zeros_like(within, dtype=bool)
+
+    quantized_arr = np.zeros_like(rgb_u8)
     masks: dict[str, Image.Image] = {}
+    canvas_px = float(width * height) if width and height else 1.0
+    unmatched_count = int(unmatched.sum())
+    unmatched_pct = round(100.0 * unmatched_count / canvas_px, 4)
+    warnings: list[str] = []
+    if unmatched_count:
+        warnings.append(
+            f"palette mask left {unmatched_count} unmatched pixels without a background layer"
+        )
+
+    layer_reports: list[PaletteDecodeLayerReport] = []
     for idx, info in enumerate(ordered):
-        mask = (nearest == idx) & within
-        if background_index is not None and idx == background_index:
-            mask = mask | ~within
+        mask = (assigned == idx) & ~unmatched
+        quantized_arr[mask] = colors_u8[idx]
+        pixel_count = int(mask.sum())
+        area_pct = round(100.0 * pixel_count / canvas_px, 4)
+        bbox = compute_mask_bbox(mask)
+        quality_status = "detected" if pixel_count else "missed"
+        layer_warnings: list[str] = []
+        if not pixel_count:
+            layer_warnings.append(f"palette mask produced empty layer: {info.name}")
+            warnings.extend(layer_warnings)
         masks[info.id] = Image.fromarray((mask.astype(np.uint8) * 255), mode="L")
-    return masks
+        layer_reports.append(
+            PaletteDecodeLayerReport(
+                layer_id=info.id,
+                name=info.name,
+                palette_color=resolved[info.name],
+                pixel_count=pixel_count,
+                area_pct=area_pct,
+                bbox=bbox,
+                quality_status=quality_status,
+                unmatched_pct=unmatched_pct,
+                warnings=layer_warnings,
+            )
+        )
+
+    report = PaletteDecodeReport(
+        width=width,
+        height=height,
+        tolerance=tolerance,
+        unmatched_pixel_count=unmatched_count,
+        unmatched_pct=unmatched_pct,
+        background_layer_id=background_layer_id,
+        warnings=warnings,
+        layers=layer_reports,
+    )
+    return masks, Image.fromarray(quantized_arr, mode="RGB"), report
+
+
+def compute_mask_bbox(mask: Image.Image | np.ndarray) -> dict[str, int] | None:
+    """Return inclusive-pixel content bounds as x/y/w/h for non-empty masks."""
+    if isinstance(mask, Image.Image):
+        arr = np.array(mask.convert("L")) > 127
+    else:
+        arr = np.asarray(mask).astype(bool)
+    if not arr.any():
+        return None
+    ys, xs = np.where(arr)
+    x0 = int(xs.min())
+    y0 = int(ys.min())
+    x1 = int(xs.max())
+    y1 = int(ys.max())
+    return {"x": x0, "y": y0, "w": x1 - x0 + 1, "h": y1 - y0 + 1}
+
+
+def write_decode_report(report: PaletteDecodeReport, output_path: str | Path) -> str:
+    path = Path(output_path)
+    path.write_text(json.dumps(asdict(report), indent=2))
+    return str(path)
+
+
+def write_palette_contact_sheet(
+    *,
+    source_image: Image.Image,
+    raw_palette: Image.Image,
+    quantized_palette: Image.Image,
+    decoded_layers: list[tuple[str, Image.Image]],
+    output_path: str | Path,
+    tile_size: tuple[int, int] = (180, 135),
+) -> str:
+    """Write a compact visual audit sheet for source, masks, and decoded layers."""
+    items: list[tuple[str, Image.Image]] = [
+        ("source", source_image.convert("RGB")),
+        ("raw palette", raw_palette.convert("RGB")),
+        ("quantized palette", quantized_palette.convert("RGB")),
+        *decoded_layers,
+    ]
+    if not items:
+        raise ValueError("contact sheet requires at least one image")
+
+    cols = min(4, len(items))
+    rows = (len(items) + cols - 1) // cols
+    pad = 10
+    label_h = 20
+    tile_w, tile_h = tile_size
+    sheet = Image.new(
+        "RGB",
+        (cols * tile_w + (cols + 1) * pad, rows * (tile_h + label_h) + (rows + 1) * pad),
+        (245, 245, 242),
+    )
+    draw = ImageDraw.Draw(sheet)
+    for idx, (label, image) in enumerate(items):
+        row = idx // cols
+        col = idx % cols
+        x = pad + col * (tile_w + pad)
+        y = pad + row * (tile_h + label_h + pad)
+        preview = _contact_sheet_preview(image)
+        thumb = ImageOps.contain(preview, tile_size)
+        tile = Image.new("RGB", tile_size, (255, 255, 255))
+        tile.paste(thumb, ((tile_w - thumb.width) // 2, (tile_h - thumb.height) // 2))
+        sheet.paste(tile, (x, y))
+        draw.text((x, y + tile_h + 4), label[:32], fill=(30, 30, 30))
+
+    path = Path(output_path)
+    sheet.save(path)
+    return str(path)
 
 
 async def split_palette(
@@ -109,6 +288,8 @@ async def split_palette(
     api_key: str = "",
     palette: dict[str, str] | None = None,
     tolerance: int = 48,
+    write_debug_artifacts: bool = True,
+    contact_sheet: bool = True,
 ) -> list[LayerResult]:
     """Split an image into layers using a provider-generated palette mask."""
     from vulca.providers import get_image_provider
@@ -134,32 +315,44 @@ async def split_palette(
 
     palette_img = Image.open(io.BytesIO(raw)).convert("RGB")
     if palette_img.size != (width, height):
-        palette_img = palette_img.resize((width, height), Image.NEAREST)
+        palette_img = palette_img.resize((width, height), Image.Resampling.NEAREST)
     palette_img.save(out_dir / "palette_mask.png")
 
-    masks = decode_palette_mask(
+    masks, quantized_img, decode_report = quantize_palette_mask(
         palette_img,
         layers,
         palette=resolved_palette,
         tolerance=tolerance,
     )
+    if write_debug_artifacts:
+        quantized_img.save(out_dir / "palette_mask_quantized.png")
+        write_decode_report(decode_report, out_dir / "decode_report.json")
 
     results: list[LayerResult] = []
-    warnings: list[str] = []
-    canvas_px = float(width * height) if width and height else 1.0
+    report_by_id = {item.layer_id: item for item in decode_report.layers}
+    decoded_previews: list[tuple[str, Image.Image]] = []
     for info in sorted(layers, key=lambda item: item.z_index):
         mask = masks.get(info.id) or Image.new("L", (width, height), 0)
-        mask_arr = np.array(mask)
-        visible_px = int((mask_arr > 127).sum())
-        info.area_pct = 100.0 * visible_px / canvas_px
-        info.quality_status = "detected" if visible_px else "missed"
-        info.dominant_colors = [resolved_palette[info.name]]
-        if not visible_px:
-            warnings.append(f"palette mask produced empty layer: {info.name}")
+        layer_report = report_by_id.get(info.id)
+        if layer_report is not None:
+            info.area_pct = layer_report.area_pct
+            info.quality_status = layer_report.quality_status
+            info.content_bbox = layer_report.bbox
+            info.dominant_colors = [layer_report.palette_color]
         layer_img = apply_mask_to_image(source, mask)
         out_path = out_dir / f"{info.name}.png"
         layer_img.save(out_path)
+        decoded_previews.append((info.name, layer_img))
         results.append(LayerResult(info=info, image_path=str(out_path)))
+
+    if write_debug_artifacts and contact_sheet:
+        write_palette_contact_sheet(
+            source_image=source,
+            raw_palette=palette_img,
+            quantized_palette=quantized_img,
+            decoded_layers=decoded_previews,
+            output_path=out_dir / "contact_sheet.png",
+        )
 
     write_manifest(
         layers,
@@ -169,10 +362,18 @@ async def split_palette(
         source_image=image_path,
         split_mode="palette",
         generation_path="palette_mask.png",
-        partial=bool(warnings),
-        warnings=warnings,
+        partial=bool(decode_report.warnings),
+        warnings=decode_report.warnings,
     )
     return results
+
+
+def _contact_sheet_preview(image: Image.Image) -> Image.Image:
+    if image.mode != "RGBA":
+        return image.convert("RGB")
+    background = Image.new("RGB", image.size, (255, 255, 255))
+    background.paste(image, mask=image.getchannel("A"))
+    return background
 
 
 def _resolve_palette(

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -751,7 +751,7 @@ async def layers_split(
         layers, manifest_path, split_mode. For orchestrated: detection_report
         with per-entity status and success_rate. When case logging succeeds,
         also returns case_id and case_log_path; when enabled logging fails,
-        returns case_log_error.
+        returns case_log_error. Palette mode also returns debug artifact paths.
     """
     from pathlib import Path
 
@@ -885,6 +885,13 @@ async def layers_split(
             for r in results
         ],
     }
+    if mode == "palette":
+        payload.update({
+            "palette_mask_path": str(Path(out) / "palette_mask.png"),
+            "palette_mask_quantized_path": str(Path(out) / "palette_mask_quantized.png"),
+            "decode_report_path": str(Path(out) / "decode_report.json"),
+            "contact_sheet_path": str(Path(out) / "contact_sheet.png"),
+        })
 
     from vulca.layers.decompose_cases import (
         append_decompose_case,

--- a/tests/test_palette_mask.py
+++ b/tests/test_palette_mask.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import argparse
 import base64
+import contextlib
 import io
 import json
 import os
@@ -55,6 +57,10 @@ def _palette_mask(*, fuzzy: bool = False) -> Image.Image:
         for x in range(3, 6):
             pixels[x, y] = right
     return img
+
+
+def _palette_mask_missing_icon() -> Image.Image:
+    return Image.new("RGB", (6, 4), (255, 0, 0))
 
 
 def _mock_provider(mask: Image.Image) -> MagicMock:
@@ -155,6 +161,229 @@ def test_split_palette_calls_provider_once_and_writes_layers():
 
         manifest = json.loads((Path(td) / "manifest.json").read_text())
         assert manifest["split_mode"] == "palette"
+
+
+def test_split_palette_writes_quantized_mask_for_exact_colors():
+    from vulca.layers.palette_mask import split_palette
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with patch("vulca.providers.get_image_provider", return_value=provider):
+            asyncio.run(
+                split_palette(
+                    str(source_path),
+                    [product, icon],
+                    output_dir=td,
+                    provider="nb2",
+                    palette={"product": "#ff0000", "icon": "#00ff00"},
+                )
+            )
+
+        quantized = Image.open(Path(td) / "palette_mask_quantized.png").convert("RGB")
+        assert quantized.size == (6, 4)
+        colors = set(map(tuple, np.array(quantized).reshape(-1, 3)))
+        assert colors == {(255, 0, 0), (0, 255, 0)}
+
+
+def test_split_palette_quantizes_near_color_mask():
+    from vulca.layers.palette_mask import split_palette
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask(fuzzy=True))
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with patch("vulca.providers.get_image_provider", return_value=provider):
+            asyncio.run(
+                split_palette(
+                    str(source_path),
+                    [product, icon],
+                    output_dir=td,
+                    provider="nb2",
+                    palette={"product": "#ff0000", "icon": "#00ff00"},
+                    tolerance=24,
+                )
+            )
+
+        quantized = Image.open(Path(td) / "palette_mask_quantized.png").convert("RGB")
+        colors = set(map(tuple, np.array(quantized).reshape(-1, 3)))
+        assert colors == {(255, 0, 0), (0, 255, 0)}
+
+
+def test_split_palette_decode_report_and_manifest_include_layer_quality():
+    from vulca.layers.palette_mask import split_palette
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with patch("vulca.providers.get_image_provider", return_value=provider):
+            asyncio.run(
+                split_palette(
+                    str(source_path),
+                    [product, icon],
+                    output_dir=td,
+                    provider="nb2",
+                    palette={"product": "#ff0000", "icon": "#00ff00"},
+                )
+            )
+
+        report = json.loads((Path(td) / "decode_report.json").read_text())
+        by_name = {item["name"]: item for item in report["layers"]}
+        assert report["unmatched_pct"] == 0.0
+        assert by_name["product"]["palette_color"] == "#ff0000"
+        assert by_name["product"]["pixel_count"] == 12
+        assert by_name["product"]["area_pct"] == 50.0
+        assert by_name["product"]["bbox"] == {"x": 0, "y": 0, "w": 3, "h": 4}
+        assert by_name["product"]["quality_status"] == "detected"
+
+        manifest = json.loads((Path(td) / "manifest.json").read_text())
+        manifest_by_name = {item["name"]: item for item in manifest["layers"]}
+        assert manifest_by_name["product"]["content_bbox"] == {"x": 0, "y": 0, "w": 3, "h": 4}
+        assert manifest_by_name["product"]["area_pct"] == 50.0
+        assert manifest_by_name["product"]["quality_status"] == "detected"
+        assert manifest_by_name["product"]["dominant_colors"] == ["#ff0000"]
+
+
+def test_split_palette_empty_layer_is_reported_as_missed():
+    from vulca.layers.palette_mask import split_palette
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask_missing_icon())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with patch("vulca.providers.get_image_provider", return_value=provider):
+            asyncio.run(
+                split_palette(
+                    str(source_path),
+                    [product, icon],
+                    output_dir=td,
+                    provider="nb2",
+                    palette={"product": "#ff0000", "icon": "#00ff00"},
+                )
+            )
+
+        report = json.loads((Path(td) / "decode_report.json").read_text())
+        by_name = {item["name"]: item for item in report["layers"]}
+        assert by_name["icon"]["quality_status"] == "missed"
+        assert by_name["icon"]["pixel_count"] == 0
+        assert by_name["icon"]["bbox"] is None
+        assert any("empty layer: icon" in warning for warning in report["warnings"])
+
+        manifest = json.loads((Path(td) / "manifest.json").read_text())
+        assert any("empty layer: icon" in warning for warning in manifest["warnings"])
+
+
+def test_split_palette_writes_contact_sheet():
+    from vulca.layers.palette_mask import split_palette
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with patch("vulca.providers.get_image_provider", return_value=provider):
+            asyncio.run(
+                split_palette(
+                    str(source_path),
+                    [product, icon],
+                    output_dir=td,
+                    provider="nb2",
+                    palette={"product": "#ff0000", "icon": "#00ff00"},
+                )
+            )
+
+        contact_sheet = Image.open(Path(td) / "contact_sheet.png")
+        assert contact_sheet.size[0] > 6
+        assert contact_sheet.size[1] > 4
+
+
+def test_mcp_layers_split_palette_payload_includes_debug_artifact_paths():
+    from vulca.mcp_server import layers_split
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+
+        with (
+            patch("vulca.layers.analyze.analyze_layers", AsyncMock(return_value=[product, icon])),
+            patch("vulca.providers.get_image_provider", return_value=provider),
+        ):
+            payload = asyncio.run(
+                layers_split(
+                    str(source_path),
+                    output_dir=td,
+                    mode="palette",
+                    provider="nb2",
+                )
+            )
+
+        for key in (
+            "palette_mask_path",
+            "palette_mask_quantized_path",
+            "decode_report_path",
+            "contact_sheet_path",
+        ):
+            assert Path(payload[key]).exists()
+
+
+def test_cli_layers_split_palette_prints_debug_artifact_paths():
+    from vulca.cli import _cmd_layers
+
+    product = _layer("product", 2)
+    icon = _layer("icon", 1)
+    provider = _mock_provider(_palette_mask())
+
+    with tempfile.TemporaryDirectory() as td:
+        source_path = Path(td) / "source.png"
+        _source_image().save(source_path)
+        args = argparse.Namespace(
+            layers_command="split",
+            image=str(source_path),
+            output=td,
+            mode="palette",
+            provider="nb2",
+            tradition="default",
+            case_log="",
+        )
+
+        stdout = io.StringIO()
+        with (
+            contextlib.redirect_stdout(stdout),
+            patch("vulca.layers.analyze.analyze_layers", AsyncMock(return_value=[product, icon])),
+            patch("vulca.providers.get_image_provider", return_value=provider),
+        ):
+            _cmd_layers(args)
+
+        output = stdout.getvalue()
+        assert "palette_mask.png" in output
+        assert "palette_mask_quantized.png" in output
+        assert "decode_report.json" in output
+        assert "contact_sheet.png" in output
 
 
 def test_split_palette_importable_from_layers():


### PR DESCRIPTION
## Summary
- Add palette mask quantization artifacts: `palette_mask_quantized.png`, `decode_report.json`, and `contact_sheet.png` alongside the existing raw `palette_mask.png`.
- Populate palette layer manifest quality fields from the decode report: `content_bbox`, `area_pct`, `quality_status`, and palette color in `dominant_colors`.
- Return/print palette debug artifact paths from MCP/CLI palette split surfaces.

## Test Plan
- `PYTHONPATH=src python3 -m pytest tests/test_palette_mask.py tests/test_v012_split_vlm.py -q` (`28 passed`)
- Real NB2 smoke with `GEMINI_API_KEY` loaded from macOS Keychain in a temporary venv:
  - output_dir: `/tmp/vulca-nb2-palette-out.1d21DV`
  - decoded area_pct: `red_block=25.603`, `blue_disc=14.7339`, `background=59.6631`
  - contact_sheet generated: yes
  - NB2 near-colors still observed: yes (`raw_non_palette_pct=71.0205`)
