### PR TITLE
[codex] Keep mock layer split analysis offline

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -1454,7 +1454,9 @@ def _cmd_layers(args: argparse.Namespace) -> None:
     if args.layers_command == "analyze":
         from vulca.layers.analyze import analyze_layers
         loop = asyncio.new_event_loop()
-        layers = loop.run_until_complete(analyze_layers(args.image))
+        layers = loop.run_until_complete(
+            analyze_layers(args.image, provider=args.provider)
+        )
         loop.close()
         print(f"\n  Identified {len(layers)} layers:")
         for la in layers:
@@ -1466,7 +1468,9 @@ def _cmd_layers(args: argparse.Namespace) -> None:
     elif args.layers_command == "split":
         from vulca.layers.analyze import analyze_layers
         loop = asyncio.new_event_loop()
-        layers = loop.run_until_complete(analyze_layers(args.image))
+        layers = loop.run_until_complete(
+            analyze_layers(args.image, provider=args.provider)
+        )
         out_dir = args.output or str(Path(args.image).parent / "layers")
         print(f"\n  Splitting {len(layers)} layers ({args.mode} mode) -> {out_dir}")
         if args.mode == "extract":

--- a/src/vulca/layers/analyze.py
+++ b/src/vulca/layers/analyze.py
@@ -56,12 +56,35 @@ def parse_layer_response(raw: dict) -> list[LayerInfo]:
     return parse_v2_response(raw)
 
 
-async def analyze_layers(image_path: str, *, api_key: str = "") -> list[LayerInfo]:
+async def analyze_layers(
+    image_path: str,
+    *,
+    api_key: str = "",
+    provider: str = "",
+) -> list[LayerInfo]:
     """Use VLM to identify semantic layers in an image.
 
     Retries up to _MAX_RETRIES times on transient failures.
     Uses V2 prompt from build_analyze_prompt().
     """
+    if provider == "mock":
+        return [
+            LayerInfo(
+                name="background",
+                description="Mock background layer",
+                z_index=0,
+                content_type="background",
+                dominant_colors=["#7890a8"],
+            ),
+            LayerInfo(
+                name="foreground",
+                description="Mock foreground layer",
+                z_index=1,
+                content_type="subject",
+                dominant_colors=[],
+            ),
+        ]
+
     from vulca._image import load_image_base64
 
     img_b64, mime = await load_image_base64(image_path)

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -843,7 +843,7 @@ async def layers_split(
     from vulca.layers.analyze import analyze_layers as _analyze
     from vulca.layers.split import split_extract, split_regenerate
 
-    layers = await _analyze(image_path)
+    layers = await _analyze(image_path, provider=provider)
     out = output_dir or str(Path(image_path).parent / "layers")
 
     if mode == "extract":

--- a/src/vulca/pipeline/nodes/plan_layers.py
+++ b/src/vulca/pipeline/nodes/plan_layers.py
@@ -90,7 +90,11 @@ class PlanLayersNode(PipelineNode):
 
     async def _analyze_existing(self, ctx: NodeContext) -> list[LayerInfo]:
         from vulca.layers import analyze_layers
-        return await analyze_layers(ctx.get("source_image_path", ""), api_key=ctx.api_key)
+        return await analyze_layers(
+            ctx.get("source_image_path", ""),
+            api_key=ctx.api_key,
+            provider=ctx.provider,
+        )
 
     def _mock_plan(self, tradition: str) -> list[LayerInfo]:
         order = get_tradition_layer_order(tradition)

--- a/tests/test_mcp_layers_mock_provider.py
+++ b/tests/test_mcp_layers_mock_provider.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import argparse
+import sys
+import types
+from unittest.mock import AsyncMock
+
+from PIL import Image
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FastMCPStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def tool(self, *args, **kwargs):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    def run(self):
+        pass
+
+
+def _install_fastmcp_stub(monkeypatch):
+    module = types.ModuleType("fastmcp")
+    module.FastMCP = _FastMCPStub
+    monkeypatch.setitem(sys.modules, "fastmcp", module)
+
+
+def test_layers_split_mock_provider_uses_mock_analysis(tmp_path, monkeypatch):
+    """MCP layers_split(provider='mock') must not call Gemini during analysis."""
+    _install_fastmcp_stub(monkeypatch)
+
+    from vulca.layers import analyze as analyze_mod
+    from vulca.mcp_server import layers_split
+
+    source = tmp_path / "source.png"
+    Image.new("RGB", (6, 4), (120, 160, 200)).save(source)
+    out_dir = tmp_path / "layers"
+    observed: dict[str, str] = {}
+    original_analyze = analyze_mod.analyze_layers
+
+    async def _recording_analyze(image_path: str, **kwargs):
+        observed.update(kwargs)
+        return await original_analyze(image_path, **kwargs)
+
+    monkeypatch.setattr(analyze_mod, "analyze_layers", _recording_analyze)
+    monkeypatch.setattr(
+        analyze_mod.litellm,
+        "acompletion",
+        AsyncMock(side_effect=AssertionError("mock provider called LiteLLM")),
+    )
+
+    result = _run(
+        layers_split(
+            image_path=str(source),
+            output_dir=str(out_dir),
+            mode="extract",
+            provider="mock",
+        )
+    )
+
+    assert observed["provider"] == "mock"
+    assert result["split_mode"] == "extract"
+    assert (out_dir / "manifest.json").exists()
+
+
+def test_cli_layers_split_mock_provider_uses_mock_analysis(tmp_path, monkeypatch):
+    """CLI layers split --provider mock must keep analysis offline too."""
+    from vulca.cli import _cmd_layers
+    from vulca.layers import analyze as analyze_mod
+
+    source = tmp_path / "source.png"
+    Image.new("RGB", (6, 4), (120, 160, 200)).save(source)
+    out_dir = tmp_path / "layers"
+    observed: dict[str, str] = {}
+    original_analyze = analyze_mod.analyze_layers
+
+    async def _recording_analyze(image_path: str, **kwargs):
+        observed.update(kwargs)
+        return await original_analyze(image_path, **kwargs)
+
+    monkeypatch.setattr(analyze_mod, "analyze_layers", _recording_analyze)
+    monkeypatch.setattr(
+        analyze_mod.litellm,
+        "acompletion",
+        AsyncMock(side_effect=AssertionError("mock provider called LiteLLM")),
+    )
+
+    _cmd_layers(
+        argparse.Namespace(
+            layers_command="split",
+            image=str(source),
+            output=str(out_dir),
+            mode="extract",
+            provider="mock",
+            tradition="default",
+            case_log="",
+        )
+    )
+
+    assert observed["provider"] == "mock"
+    assert (out_dir / "manifest.json").exists()

--- a/tests/test_review_followups.py
+++ b/tests/test_review_followups.py
@@ -92,6 +92,23 @@ async def test_analyze_layers_no_api_base_for_cloud():
             assert call_kwargs.get("api_key") == "fake"
 
 
+def test_analyze_layers_mock_provider_does_not_call_litellm():
+    """provider='mock' must keep layer analysis local/offline."""
+    import asyncio
+
+    from vulca.layers import analyze as analyze_mod
+
+    with patch.object(
+        analyze_mod.litellm,
+        "acompletion",
+        new=AsyncMock(side_effect=AssertionError("mock analysis called LiteLLM")),
+    ):
+        layers = asyncio.run(analyze_mod.analyze_layers("dummy.png", provider="mock"))
+
+    assert [layer.name for layer in layers] == ["background", "foreground"]
+    assert [layer.content_type for layer in layers] == ["background", "subject"]
+
+
 # --- ComfyUI: shared transport fixture ------------------------------------
 
 @contextmanager

--- a/tests/vulca/pipeline/nodes/test_plan_layers_max_layers.py
+++ b/tests/vulca/pipeline/nodes/test_plan_layers_max_layers.py
@@ -1,7 +1,9 @@
 """Phase 0 Task 0 rework: plan_layers must respect ctx.max_layers up to 20."""
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
+from PIL import Image
 
 from vulca.layers.types import LayerInfo
 from vulca.pipeline.node import NodeContext
@@ -49,3 +51,25 @@ def test_plan_layers_defaults_to_legacy_cap_when_unset():
     ctx.set("planned_layers", _make_layers(15))
     out = _run(ctx)
     assert out["layer_count"] == 10
+
+
+def test_plan_layers_existing_source_mock_provider_skips_litellm(tmp_path, monkeypatch):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (6, 4), (120, 160, 200)).save(source)
+
+    import vulca.layers.analyze as analyze_mod
+
+    monkeypatch.setattr(
+        analyze_mod.litellm,
+        "acompletion",
+        AsyncMock(side_effect=AssertionError("mock provider called LiteLLM")),
+    )
+
+    ctx = NodeContext(subject="x", tradition="default", provider="mock")
+    ctx.set("source_image_b64", "AAAA")
+    ctx.set("source_image_path", str(source))
+
+    out = _run(ctx)
+
+    assert out["layer_count"] == 2
+    assert [layer.name for layer in out["planned_layers"]] == ["background", "foreground"]


### PR DESCRIPTION
## Summary
- Add `provider="mock"` support to `analyze_layers` so layer analysis can stay local/offline.
- Pass the selected provider through MCP, CLI, and existing-source pipeline layer analysis.
- Add regressions covering direct analysis, MCP `layers_split`, CLI `layers split`, and pipeline source-image planning.

## Root Cause
`layers_split(... provider="mock")` forwarded the provider only to the split/generation stage. The analysis stage still called `analyze_layers(image_path)` with no provider, and `analyze_layers` defaulted to LiteLLM/Gemini.

Fixes #11.

## Verification
- `PYTHONPATH=src python3.11 -m pytest tests/test_review_followups.py tests/test_mcp_layers_mock_provider.py tests/vulca/pipeline/nodes/test_plan_layers_max_layers.py tests/test_plan_layers_node.py -q` -> 31 passed
- `ruff check src/vulca/layers/analyze.py src/vulca/mcp_server.py src/vulca/cli.py src/vulca/pipeline/nodes/plan_layers.py tests/test_review_followups.py tests/test_mcp_layers_mock_provider.py tests/vulca/pipeline/nodes/test_plan_layers_max_layers.py` -> passed
- `git diff --cached --check` -> passed before commit
- `gemini-agent diff-review --stdin` on staged diff -> pass
