### PR TITLE
[codex] Add plugin package sync check

### DIFF
--- a/docs/platform/claude-plugin-marketplace-checklist.md
+++ b/docs/platform/claude-plugin-marketplace-checklist.md
@@ -44,14 +44,16 @@ The marketplace plugin root is the repository root:
 The source of truth for skill authoring remains `.agents/skills/`. Run this after changing a skill:
 
 ```bash
-python scripts/sync_plugin_skills.py
+python scripts/sync_plugin.py
+python scripts/sync_plugin.py --check
 ```
 
 That syncs:
 
 - `.claude/skills/` for project-local Claude iteration;
 - `skills/` for Claude plugin packaging;
-- `plugins/vulca/skills/` for Codex plugin packaging.
+- `plugins/vulca/skills/` for Codex plugin packaging;
+- `plugins/vulca/README.md` and plugin manifest versions from SDK source truth.
 
 ## Pre-Submission Gate
 

--- a/docs/platform/manual-review-checklist.md
+++ b/docs/platform/manual-review-checklist.md
@@ -25,7 +25,8 @@ Use this checklist before merging or submitting Vulca to a plugin directory.
 Run:
 
 ```bash
-python scripts/sync_plugin_skills.py
+python scripts/sync_plugin.py
+python scripts/sync_plugin.py --check
 python -m pytest tests/test_visual_discovery_docs_truth.py tests/test_prompting.py -q
 ```
 

--- a/docs/platform/openai-codex-mcp-guide.md
+++ b/docs/platform/openai-codex-mcp-guide.md
@@ -32,7 +32,8 @@ The package is intentionally self-contained for Codex validation. The copied ski
 Run:
 
 ```bash
-python scripts/sync_plugin_skills.py
+python scripts/sync_plugin.py
+python scripts/sync_plugin.py --check
 ```
 
 Observed local CLI:

--- a/docs/platform/release-readiness-status.md
+++ b/docs/platform/release-readiness-status.md
@@ -60,10 +60,11 @@ Observed skills:
 - `vulca:visual-plan`
 
 ```bash
-/opt/homebrew/bin/python3 scripts/sync_plugin_skills.py
+/opt/homebrew/bin/python3 scripts/sync_plugin.py
+/opt/homebrew/bin/python3 scripts/sync_plugin.py --check
 ```
 
-Observed: synced `.agents/skills` into `.claude/skills`, `skills`, and `plugins/vulca/skills`.
+Observed: synced `.agents/skills` into `.claude/skills`, `skills`, and `plugins/vulca/skills`, then checked plugin package README and manifest drift.
 
 ```bash
 /opt/homebrew/bin/python3 -m pytest tests/test_prompting.py tests/test_visual_discovery_docs_truth.py tests/test_visual_discovery_prompting.py tests/test_visual_discovery_benchmark.py tests/test_gemini_image_size.py tests/test_generate_image_extended_signature.py -q

--- a/plugins/vulca/README.md
+++ b/plugins/vulca/README.md
@@ -1,0 +1,49 @@
+# Vulca Plugin Package
+
+Generated package metadata for Vulca SDK `0.23.1`.
+
+## MCP Tools
+
+| Tool |
+|---|
+| `archive_session` |
+| `brief_parse` |
+| `compose_prompt_from_design` |
+| `create_artwork` |
+| `evaluate_artwork` |
+| `generate_concepts` |
+| `generate_image` |
+| `get_tradition_guide` |
+| `inpaint_artwork` |
+| `layers_composite` |
+| `layers_edit` |
+| `layers_evaluate` |
+| `layers_export` |
+| `layers_list` |
+| `layers_paste_back` |
+| `layers_redraw` |
+| `layers_split` |
+| `layers_transform` |
+| `list_traditions` |
+| `search_traditions` |
+| `sync_data` |
+| `unload_models` |
+| `view_image` |
+
+## Skills
+
+- `decompose`
+- `evaluate`
+- `using-vulca-skills`
+- `visual-brainstorm`
+- `visual-discovery`
+- `visual-plan`
+- `visual-spec`
+
+## Release Check
+
+Run this from the Vulca SDK repository before tagging a release:
+
+```bash
+python scripts/sync_plugin.py --check
+```

--- a/scripts/sync_plugin.py
+++ b/scripts/sync_plugin.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Synchronize generated Vulca plugin package files from SDK source truth."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL_TARGETS = (".claude/skills", "skills")
+
+
+class SyncResult:
+    def __init__(self, *, changed: bool, messages: list[str]) -> None:
+        self.changed = changed
+        self.messages = messages
+
+
+def _is_mcp_tool_decorator(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "tool"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "mcp"
+    )
+
+
+def extract_mcp_tool_names(path: Path) -> list[str]:
+    """Return names of functions decorated with @mcp.tool() without importing MCP."""
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: list[str] = []
+    for node in ast.walk(module):
+        if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
+            continue
+        if any(_is_mcp_tool_decorator(decorator) for decorator in node.decorator_list):
+            names.append(node.name)
+    return sorted(names)
+
+
+def _project_version(pyproject: Path) -> str:
+    in_project = False
+    for raw_line in pyproject.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line == "[project]":
+            in_project = True
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            in_project = False
+        if not in_project:
+            continue
+        match = re.match(r'version\s*=\s*"([^"]+)"', line)
+        if match:
+            return match.group(1)
+    raise ValueError(f"could not find [project] version in {pyproject}")
+
+
+def _skill_names(source: Path) -> list[str]:
+    return sorted(path.parent.name for path in source.glob("*/SKILL.md"))
+
+
+def _read_file_map(directory: Path) -> dict[str, bytes]:
+    if not directory.exists():
+        return {}
+    return {
+        path.relative_to(directory).as_posix(): path.read_bytes()
+        for path in sorted(directory.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _copy_tree(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target)
+
+
+def _rel(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _write_if_changed(path: Path, content: str, *, check: bool) -> bool:
+    old = path.read_text(encoding="utf-8") if path.exists() else None
+    if old == content:
+        return False
+    if not check:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return True
+
+
+def _sync_json_version(path: Path, version: str, *, check: bool) -> bool:
+    if not path.exists():
+        return False
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("version") == version:
+        return False
+    payload["version"] = version
+    if not check:
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def _plugin_readme(*, version: str, tools: list[str], skills: list[str]) -> str:
+    tool_rows = "\n".join(f"| `{tool}` |" for tool in tools)
+    skill_rows = "\n".join(f"- `{skill}`" for skill in skills)
+    return f"""# Vulca Plugin Package
+
+Generated package metadata for Vulca SDK `{version}`.
+
+## MCP Tools
+
+| Tool |
+|---|
+{tool_rows}
+
+## Skills
+
+{skill_rows}
+
+## Release Check
+
+Run this from the Vulca SDK repository before tagging a release:
+
+```bash
+python scripts/sync_plugin.py --check
+```
+"""
+
+
+def _sync_skill_target(root: Path, source: Path, target: Path, *, check: bool) -> tuple[bool, str]:
+    changed = _read_file_map(source) != _read_file_map(target)
+    if changed and not check:
+        _copy_tree(source, target)
+    return changed, f"{_rel(root, target)} is out of sync"
+
+
+def sync_plugin_package(
+    *,
+    root: Path = ROOT,
+    plugin_root: Path | None = None,
+    check: bool = False,
+) -> SyncResult:
+    root = Path(root).resolve()
+    plugin_root = Path(plugin_root).resolve() if plugin_root else root / "plugins" / "vulca"
+    skills_source = root / ".agents" / "skills"
+    if not skills_source.is_dir():
+        raise FileNotFoundError(f"missing canonical skills directory: {skills_source}")
+
+    version = _project_version(root / "pyproject.toml")
+    tools = extract_mcp_tool_names(root / "src" / "vulca" / "mcp_server.py")
+    skills = _skill_names(skills_source)
+    changed = False
+    messages: list[str] = []
+
+    for relative in SKILL_TARGETS:
+        target = root / relative
+        target_changed, message = _sync_skill_target(root, skills_source, target, check=check)
+        if target_changed:
+            changed = True
+            messages.append(message)
+
+    plugin_skill_changed, plugin_skill_message = _sync_skill_target(
+        root, skills_source, plugin_root / "skills", check=check
+    )
+    if plugin_skill_changed:
+        changed = True
+        messages.append(plugin_skill_message)
+
+    for manifest in (
+        root / ".claude-plugin" / "plugin.json",
+        plugin_root / ".claude-plugin" / "plugin.json",
+        plugin_root / ".codex-plugin" / "plugin.json",
+    ):
+        if _sync_json_version(manifest, version, check=check):
+            changed = True
+            messages.append(f"{_rel(root, manifest)} is out of sync")
+
+    readme = plugin_root / "README.md"
+    if _write_if_changed(
+        readme,
+        _plugin_readme(version=version, tools=tools, skills=skills),
+        check=check,
+    ):
+        changed = True
+        messages.append(f"{_rel(root, readme)} is out of sync")
+
+    if not messages:
+        messages.append("plugin package is in sync")
+    return SyncResult(changed=changed, messages=messages)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="Vulca SDK repository root")
+    parser.add_argument(
+        "--plugin-root",
+        type=Path,
+        default=None,
+        help="Plugin package root; defaults to <root>/plugins/vulca",
+    )
+    parser.add_argument("--check", action="store_true", help="report drift without writing")
+    args = parser.parse_args(argv)
+
+    result = sync_plugin_package(
+        root=args.root,
+        plugin_root=args.plugin_root,
+        check=args.check,
+    )
+    for message in result.messages:
+        print(message)
+    return 1 if args.check and result.changed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_plugin_skills.py
+++ b/scripts/sync_plugin_skills.py
@@ -1,34 +1,12 @@
 #!/usr/bin/env python3
-"""Synchronize Vulca skills into platform plugin package locations."""
+"""Compatibility entrypoint for the full Vulca plugin package sync."""
 
 from __future__ import annotations
 
-import shutil
-from pathlib import Path
+import sys
 
-
-ROOT = Path(__file__).resolve().parent.parent
-SOURCE = ROOT / ".agents" / "skills"
-TARGETS = [
-    ROOT / ".claude" / "skills",
-    ROOT / "skills",
-    ROOT / "plugins" / "vulca" / "skills",
-]
-
-
-def _sync_tree(source: Path, target: Path) -> None:
-    if not source.is_dir():
-        raise SystemExit(f"missing source skills directory: {source}")
-    if target.exists():
-        shutil.rmtree(target)
-    shutil.copytree(source, target)
-
-
-def main() -> None:
-    for target in TARGETS:
-        _sync_tree(SOURCE, target)
-        print(f"synced {SOURCE.relative_to(ROOT)} -> {target.relative_to(ROOT)}")
+from sync_plugin import main
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_sync_plugin.py
+++ b/tests/test_sync_plugin.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_sync_plugin():
+    spec = importlib.util.spec_from_file_location(
+        "sync_plugin", ROOT / "scripts" / "sync_plugin.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_fixture_repo(root: Path) -> None:
+    (root / "src" / "vulca").mkdir(parents=True)
+    (root / ".agents" / "skills" / "decompose").mkdir(parents=True)
+    (root / ".agents" / "skills" / "evaluate").mkdir(parents=True)
+    (root / "plugins" / "vulca" / ".codex-plugin").mkdir(parents=True)
+    (root / "plugins" / "vulca" / "skills" / "stale").mkdir(parents=True)
+
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "vulca"\nversion = "9.8.7"\n',
+        encoding="utf-8",
+    )
+    (root / "src" / "vulca" / "mcp_server.py").write_text(
+        """
+from fastmcp import FastMCP
+
+mcp = FastMCP("VULCA")
+
+@mcp.tool()
+async def create_artwork(intent: str) -> dict:
+    return {}
+
+@mcp.tool()
+def evaluate_artwork(image_path: str) -> dict:
+    return {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (root / ".agents" / "skills" / "decompose" / "SKILL.md").write_text(
+        "---\nname: decompose\ndescription: Split images.\n---\n",
+        encoding="utf-8",
+    )
+    (root / ".agents" / "skills" / "evaluate" / "SKILL.md").write_text(
+        "---\nname: evaluate\ndescription: Score images.\n---\n",
+        encoding="utf-8",
+    )
+    (root / "plugins" / "vulca" / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "vulca", "version": "0.0.1", "skills": "./skills/"}),
+        encoding="utf-8",
+    )
+    (root / "plugins" / "vulca" / "skills" / "stale" / "SKILL.md").write_text(
+        "stale",
+        encoding="utf-8",
+    )
+
+
+def test_extracts_mcp_tool_names_without_importing_fastmcp():
+    sync_plugin = _load_sync_plugin()
+
+    tools = sync_plugin.extract_mcp_tool_names(ROOT / "src" / "vulca" / "mcp_server.py")
+
+    assert "create_artwork" in tools
+    assert "evaluate_artwork" in tools
+    assert tools == sorted(tools)
+
+
+def test_sync_plugin_updates_manifest_skills_and_readme(tmp_path):
+    sync_plugin = _load_sync_plugin()
+    _write_fixture_repo(tmp_path)
+
+    result = sync_plugin.sync_plugin_package(root=tmp_path)
+
+    assert result.changed
+    manifest = json.loads(
+        (
+            tmp_path
+            / "plugins"
+            / "vulca"
+            / ".codex-plugin"
+            / "plugin.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert manifest["version"] == "9.8.7"
+
+    copied_skills = {
+        path.parent.name
+        for path in (tmp_path / "plugins" / "vulca" / "skills").glob("*/SKILL.md")
+    }
+    assert copied_skills == {"decompose", "evaluate"}
+
+    readme = (tmp_path / "plugins" / "vulca" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert "| `create_artwork` |" in readme
+    assert "| `evaluate_artwork` |" in readme
+    assert "decompose" in readme
+    assert "stale" not in readme
+
+
+def test_sync_plugin_check_reports_drift_without_modifying(tmp_path):
+    _write_fixture_repo(tmp_path)
+    stale_manifest = (
+        tmp_path / "plugins" / "vulca" / ".codex-plugin" / "plugin.json"
+    ).read_text(encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "sync_plugin.py"),
+            "--root",
+            str(tmp_path),
+            "--check",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "plugins/vulca/.codex-plugin/plugin.json is out of sync" in completed.stdout
+    assert "plugins/vulca/skills is out of sync" in completed.stdout
+    assert (
+        tmp_path / "plugins" / "vulca" / ".codex-plugin" / "plugin.json"
+    ).read_text(encoding="utf-8") == stale_manifest
+
+
+def test_legacy_skill_sync_entrypoint_delegates_to_full_sync(tmp_path):
+    _write_fixture_repo(tmp_path)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "sync_plugin_skills.py"),
+            "--root",
+            str(tmp_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert (tmp_path / "plugins" / "vulca" / "README.md").exists()
+    manifest = json.loads(
+        (
+            tmp_path
+            / "plugins"
+            / "vulca"
+            / ".codex-plugin"
+            / "plugin.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert manifest["version"] == "9.8.7"


### PR DESCRIPTION
## Summary
- add `scripts/sync_plugin.py` to sync/check plugin package assets from SDK source truth
- generate the repo-local Codex plugin README from the current MCP tool list and canonical skills
- keep `scripts/sync_plugin_skills.py` as a compatibility wrapper for the full sync
- update platform/release checklists to require `sync_plugin.py --check`

## Why
Plugin package drift was previously only caught manually. This gives release work a deterministic check for skill mirrors, plugin README drift, and plugin manifest version drift.

Closes #8

## Validation
- `PYTHONPATH=src python3.11 -m pytest tests/test_sync_plugin.py tests/test_visual_discovery_docs_truth.py -q`
- `python3.11 scripts/sync_plugin.py --check`
- `python3.11 -m ruff check scripts/sync_plugin.py scripts/sync_plugin_skills.py tests/test_sync_plugin.py`
- `python3.11 -m py_compile scripts/sync_plugin.py scripts/sync_plugin_skills.py tests/test_sync_plugin.py`
- `git diff --cached --check`
- `gemini-agent diff-review --stdin` -> pass
