### PR TITLE
[codex] Add opt-in runtime telemetry

### DIFF
--- a/docs/platform/telemetry-policy.md
+++ b/docs/platform/telemetry-policy.md
@@ -1,0 +1,67 @@
+# Vulca Telemetry Policy
+
+Vulca runtime telemetry is off by default. SDK, CLI, and MCP behavior must be identical when telemetry is disabled, and network failures must never affect a user workflow.
+
+## Enabling And Disabling
+
+Telemetry can be enabled by either:
+
+- setting `VULCA_TELEMETRY=1`; or
+- running `vulca telemetry enable`, which writes local config under the Vulca config directory.
+
+Telemetry is disabled by default, by `VULCA_TELEMETRY=0`, by `vulca telemetry disable`, and always by `DO_NOT_TRACK=1`. `DO_NOT_TRACK=1` wins over every opt-in source.
+
+Use `vulca telemetry status` to inspect the current state, config path, and anonymous install id status. Use `vulca telemetry reset-id` to delete the local anonymous install id.
+
+## Event Envelope
+
+Every emitted event uses this envelope:
+
+- `event`
+- `vulca_version`
+- `python_version`
+- `platform`
+- `interface`: `cli`, `mcp`, or `sdk`
+- `session_id`
+- `anonymous_install_id`
+- `timestamp`
+- `properties`
+
+The anonymous install id is a locally generated random UUID string. It is not derived from usernames, hostnames, file paths, API keys, prompts, images, or hardware identifiers.
+
+## Allowed Events
+
+Current runtime events:
+
+- `cli_invoked`: command group only, such as `create`, `evaluate`, or `telemetry`.
+- `mcp_server_started`: transport only.
+- `mcp_tool_called`: tool name, status, and duration bucket only.
+
+Future provider events may record provider id, success/failure, duration bucket, and usage/cost presence booleans, but not request content.
+
+## Forbidden Fields
+
+Telemetry must never include:
+
+- prompts or user creative intent text;
+- image paths or other local file paths;
+- image bytes, masks, base64 payloads, or generated media;
+- API keys, tokens, credentials, or account identifiers;
+- local usernames, hostnames, or direct contact/payment identifiers;
+- full stack traces or raw exception payloads.
+
+The telemetry client uses an allowlist for event properties. Unknown property keys are dropped instead of scrubbed heuristically.
+
+## Sink Behavior
+
+If `VULCA_TELEMETRY_ENDPOINT` is unset, the default sink is a no-op even when telemetry is enabled. Tests and deployments may pass an explicit sink for controlled collection. Sink exceptions and network failures are swallowed and reported as an unsent event to the caller.
+
+## Usage Runbook
+
+To answer whether people are actually using Vulca:
+
+1. Compare GitHub and PyPI awareness/install signals with runtime opt-in events.
+2. Count `cli_invoked`, `mcp_server_started`, and first `mcp_tool_called` by anonymous install id.
+3. Segment MCP depth by tool name, especially `layers_split`, `evaluate_artwork`, provider-backed generation, and remote profile starts.
+4. Treat missing telemetry as unknown, not zero usage, because telemetry is opt-in.
+5. Publish only aggregate counts; do not expose anonymous install ids in public reports.

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -154,6 +154,15 @@ def main(argv: list[str] | None = None) -> None:
     sync_parser.add_argument("--push-only", action="store_true", help="Only push local data")
     sync_parser.add_argument("--pull-only", action="store_true", help="Only pull evolved weights")
 
+    # telemetry command
+    telemetry_parser = sub.add_parser("telemetry", help="Inspect or change opt-in telemetry settings")
+    telemetry_parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    telemetry_sub = telemetry_parser.add_subparsers(dest="telemetry_command")
+    telemetry_sub.add_parser("status", help="Show telemetry status")
+    telemetry_sub.add_parser("enable", help="Enable local opt-in telemetry")
+    telemetry_sub.add_parser("disable", help="Disable local opt-in telemetry")
+    telemetry_sub.add_parser("reset-id", help="Reset the anonymous install id")
+
     # inpaint command
     inpaint_p = sub.add_parser("inpaint", help="Repaint a region of an artwork")
     inpaint_p.add_argument("image", help="Path to image")
@@ -502,6 +511,12 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
+    try:
+        from vulca.telemetry import emit_cli_invoked
+        emit_cli_invoked(args.command or "help")
+    except Exception:
+        pass
+
     if args.command in ("evaluate", "eval", "e"):
         _cmd_evaluate(args)
     elif args.command in ("create", "c"):
@@ -534,6 +549,8 @@ def main(argv: list[str] | None = None) -> None:
         _cmd_concept(args)
     elif args.command == "sync":
         _cmd_sync(args)
+    elif args.command == "telemetry":
+        _cmd_telemetry(args)
     elif args.command == "inpaint":
         _cmd_inpaint(args)
     elif args.command == "layers":
@@ -1407,6 +1424,43 @@ def _cmd_sync(args: argparse.Namespace) -> None:
         except Exception as exc:
             print(f"Pull failed: {exc}", file=sys.stderr)
             sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Telemetry command
+# ---------------------------------------------------------------------------
+
+def _cmd_telemetry(args: argparse.Namespace) -> None:
+    import json as json_mod
+    from vulca.telemetry import (
+        reset_anonymous_install_id,
+        set_telemetry_enabled,
+        telemetry_status,
+    )
+
+    command = args.telemetry_command or "status"
+    if command == "enable":
+        set_telemetry_enabled(True)
+    elif command == "disable":
+        set_telemetry_enabled(False)
+    elif command == "reset-id":
+        reset_anonymous_install_id()
+    elif command != "status":
+        print(f"Error: unknown telemetry command {command!r}", file=sys.stderr)
+        sys.exit(1)
+
+    status = telemetry_status()
+    if args.json:
+        print(json_mod.dumps(status, indent=2, ensure_ascii=False))
+        return
+
+    print("VULCA Telemetry")
+    print(f"  enabled: {str(status['enabled']).lower()}")
+    print(f"  source: {status['source']}")
+    print(f"  do_not_track: {str(status['do_not_track']).lower()}")
+    print(f"  config_path: {status['config_path']}")
+    install_id = status["anonymous_install_id"] or "(not created)"
+    print(f"  anonymous_install_id: {install_id}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -29,6 +29,17 @@ from fastmcp import FastMCP
 
 mcp = FastMCP("VULCA", instructions="AI-native cultural art creation & evaluation")
 
+try:
+    from vulca.telemetry import McpTelemetryMiddleware, TelemetryClient
+
+    mcp.add_middleware(McpTelemetryMiddleware())
+    TelemetryClient(interface="mcp").emit(
+        "mcp_server_started",
+        {"transport": "stdio"},
+    )
+except Exception:
+    pass
+
 
 _TOOL_TIERS: dict[str, str] = {
     "create_artwork": "core", "evaluate_artwork": "core",

--- a/src/vulca/telemetry.py
+++ b/src/vulca/telemetry.py
@@ -1,0 +1,252 @@
+"""Privacy-safe, opt-in telemetry helpers for Vulca runtime surfaces."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform as platform_mod
+import sys
+import time
+import uuid
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from vulca._version import __version__
+
+try:
+    from fastmcp.server.middleware import Middleware
+except Exception:  # pragma: no cover - fastmcp is optional outside MCP installs
+    class Middleware:  # type: ignore[no-redef]
+        pass
+
+
+TelemetrySink = Callable[[dict[str, Any]], object]
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
+_ALLOWED_PROPERTY_KEYS = {
+    "command",
+    "duration_bucket_ms",
+    "evaluation_error_present",
+    "profile",
+    "provider",
+    "status",
+    "step",
+    "tool_name",
+    "transport",
+    "usage_present",
+}
+_CONFIG_FILE = "telemetry.json"
+_INSTALL_ID_FILE = "anonymous_install_id"
+
+
+def _config_dir() -> Path:
+    raw = os.environ.get("VULCA_CONFIG_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".config" / "vulca"
+
+
+def _config_path() -> Path:
+    return _config_dir() / _CONFIG_FILE
+
+
+def _install_id_path() -> Path:
+    return _config_dir() / _INSTALL_ID_FILE
+
+
+def _env_bool(name: str) -> bool | None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in _TRUE:
+        return True
+    if value in _FALSE:
+        return False
+    return None
+
+
+def _load_config() -> dict[str, Any]:
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_config(payload: dict[str, Any]) -> None:
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def set_telemetry_enabled(enabled: bool) -> None:
+    config = _load_config()
+    config["enabled"] = bool(enabled)
+    _write_config(config)
+
+
+def reset_anonymous_install_id() -> None:
+    try:
+        _install_id_path().unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _enabled_state() -> tuple[bool, str]:
+    if _env_bool("DO_NOT_TRACK") is True:
+        return False, "do-not-track"
+    env_value = _env_bool("VULCA_TELEMETRY")
+    if env_value is not None:
+        return env_value, "env"
+    config = _load_config()
+    if isinstance(config.get("enabled"), bool):
+        return bool(config["enabled"]), "config"
+    return False, "default-off"
+
+
+def _current_install_id(*, create: bool) -> str:
+    path = _install_id_path()
+    if path.exists():
+        try:
+            return path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+    if not create:
+        return ""
+    value = uuid.uuid4().hex
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value + "\n", encoding="utf-8")
+    return value
+
+
+def telemetry_status() -> dict[str, Any]:
+    enabled, source = _enabled_state()
+    return {
+        "enabled": enabled,
+        "source": source,
+        "do_not_track": _env_bool("DO_NOT_TRACK") is True,
+        "config_path": str(_config_path()),
+        "anonymous_install_id": _current_install_id(create=False),
+    }
+
+
+def _scrub_properties(properties: dict[str, Any]) -> dict[str, Any]:
+    scrubbed: dict[str, Any] = {}
+    for key, value in properties.items():
+        if key not in _ALLOWED_PROPERTY_KEYS:
+            continue
+        if isinstance(value, bool | int | float | str) or value is None:
+            scrubbed[key] = value
+    return scrubbed
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _default_sink(payload: dict[str, Any]) -> bool:
+    endpoint = os.environ.get("VULCA_TELEMETRY_ENDPOINT", "").strip()
+    if not endpoint:
+        return False
+    import httpx
+
+    httpx.post(endpoint, json=payload, timeout=1.0)
+    return True
+
+
+class TelemetryClient:
+    """Small opt-in telemetry client with no-op default behavior."""
+
+    def __init__(
+        self,
+        *,
+        interface: str,
+        sink: TelemetrySink | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        enabled, source = _enabled_state()
+        self.enabled = enabled
+        self.source = source
+        self.interface = interface
+        self.session_id = session_id or uuid.uuid4().hex
+        self._sink = sink or _default_sink
+
+    def envelope(self, event: str, properties: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {
+            "event": event,
+            "vulca_version": __version__,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "platform": platform_mod.system().lower(),
+            "interface": self.interface,
+            "session_id": self.session_id,
+            "anonymous_install_id": _current_install_id(create=True),
+            "timestamp": _timestamp(),
+            "properties": _scrub_properties(properties or {}),
+        }
+
+    def emit(self, event: str, properties: dict[str, Any] | None = None) -> bool:
+        if not self.enabled:
+            return False
+        try:
+            result = self._sink(self.envelope(event, properties))
+        except Exception:
+            return False
+        return False if result is False else True
+
+
+def _duration_bucket_ms(elapsed_ms: float) -> str:
+    if elapsed_ms < 100:
+        return "<100"
+    if elapsed_ms < 500:
+        return "100-500"
+    if elapsed_ms < 1000:
+        return "500-1000"
+    if elapsed_ms < 5000:
+        return "1000-5000"
+    return "5000+"
+
+
+class McpTelemetryMiddleware(Middleware):
+    """FastMCP middleware that emits tool name/status without tool arguments."""
+
+    def __init__(self, *, client: TelemetryClient | None = None) -> None:
+        self.client = client or TelemetryClient(interface="mcp")
+
+    async def on_call_tool(self, context: Any, call_next: Callable[[Any], Any]) -> Any:
+        started = time.perf_counter()
+        tool_name = getattr(getattr(context, "message", None), "name", "unknown")
+        try:
+            result = await call_next(context)
+        except Exception:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            self.client.emit(
+                "mcp_tool_called",
+                {
+                    "tool_name": tool_name,
+                    "status": "error",
+                    "duration_bucket_ms": _duration_bucket_ms(elapsed_ms),
+                },
+            )
+            raise
+
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        self.client.emit(
+            "mcp_tool_called",
+            {
+                "tool_name": tool_name,
+                "status": "ok",
+                "duration_bucket_ms": _duration_bucket_ms(elapsed_ms),
+            },
+        )
+        return result
+
+
+def emit_cli_invoked(command: str) -> bool:
+    return TelemetryClient(interface="cli").emit("cli_invoked", {"command": command})

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VULCA = [sys.executable, "-m", "vulca"]
+
+
+def test_default_telemetry_is_noop(monkeypatch, tmp_path):
+    monkeypatch.delenv("VULCA_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setenv("VULCA_CONFIG_DIR", str(tmp_path / "config"))
+    sent = []
+
+    from vulca.telemetry import TelemetryClient
+
+    client = TelemetryClient(interface="sdk", sink=sent.append)
+
+    assert client.enabled is False
+    assert client.emit(
+        "cli_invoked",
+        {
+            "command": "evaluate",
+            "prompt": "secret prompt",
+            "image_path": "/Users/me/private/art.png",
+        },
+    ) is False
+    assert sent == []
+
+
+def test_opt_in_telemetry_scrubs_sensitive_payload(monkeypatch, tmp_path):
+    monkeypatch.setenv("VULCA_TELEMETRY", "1")
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setenv("VULCA_CONFIG_DIR", str(tmp_path / "config"))
+    sent = []
+
+    from vulca.telemetry import TelemetryClient
+
+    client = TelemetryClient(interface="mcp", sink=sent.append)
+
+    assert client.emit(
+        "mcp_tool_called",
+        {
+            "tool_name": "layers_split",
+            "status": "ok",
+            "duration_bucket_ms": "100-500",
+            "provider": "mock",
+            "prompt": "do not send",
+            "image_path": "/tmp/private.png",
+            "api_key": "secret",
+        },
+    ) is True
+
+    assert len(sent) == 1
+    payload = sent[0]
+    assert payload["event"] == "mcp_tool_called"
+    assert payload["interface"] == "mcp"
+    assert payload["anonymous_install_id"]
+    assert payload["properties"] == {
+        "tool_name": "layers_split",
+        "status": "ok",
+        "duration_bucket_ms": "100-500",
+        "provider": "mock",
+    }
+
+
+def test_do_not_track_disables_even_when_opted_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("VULCA_TELEMETRY", "1")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setenv("VULCA_CONFIG_DIR", str(tmp_path / "config"))
+    sent = []
+
+    from vulca.telemetry import TelemetryClient
+
+    client = TelemetryClient(interface="sdk", sink=sent.append)
+
+    assert client.enabled is False
+    assert client.emit("cli_invoked", {"command": "create"}) is False
+    assert sent == []
+
+
+def test_sink_failure_is_silent(monkeypatch, tmp_path):
+    monkeypatch.setenv("VULCA_TELEMETRY", "1")
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setenv("VULCA_CONFIG_DIR", str(tmp_path / "config"))
+
+    from vulca.telemetry import TelemetryClient
+
+    def broken_sink(payload):
+        raise RuntimeError("network down")
+
+    client = TelemetryClient(interface="sdk", sink=broken_sink)
+
+    assert client.emit("provider_generate_called", {"provider": "mock"}) is False
+
+
+def test_mcp_telemetry_middleware_emits_tool_status(monkeypatch, tmp_path):
+    monkeypatch.setenv("VULCA_TELEMETRY", "1")
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.setenv("VULCA_CONFIG_DIR", str(tmp_path / "config"))
+    sent = []
+
+    from vulca.telemetry import McpTelemetryMiddleware, TelemetryClient
+
+    middleware = McpTelemetryMiddleware(
+        client=TelemetryClient(interface="mcp", sink=sent.append)
+    )
+    context = SimpleNamespace(
+        message=SimpleNamespace(
+            name="layers_split",
+            arguments={"image_path": "/tmp/private.png", "prompt": "secret"},
+        )
+    )
+
+    async def call_next(_context):
+        return {"status": "ok"}
+
+    import asyncio
+
+    assert asyncio.run(middleware.on_call_tool(context, call_next)) == {"status": "ok"}
+    assert sent[0]["properties"]["tool_name"] == "layers_split"
+    assert sent[0]["properties"]["status"] == "ok"
+    assert "image_path" not in sent[0]["properties"]
+    assert "prompt" not in sent[0]["properties"]
+
+
+def test_cli_telemetry_status_enable_disable(tmp_path):
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(ROOT / "src"),
+        "VULCA_CONFIG_DIR": str(tmp_path / "config"),
+    }
+    env.pop("VULCA_TELEMETRY", None)
+    env.pop("DO_NOT_TRACK", None)
+
+    status = subprocess.run(
+        VULCA + ["telemetry", "status"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    assert status.returncode == 0
+    assert "enabled: false" in status.stdout
+    assert "default-off" in status.stdout
+
+    enabled = subprocess.run(
+        VULCA + ["telemetry", "enable"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    assert enabled.returncode == 0
+    assert "enabled: true" in enabled.stdout
+
+    disabled = subprocess.run(
+        VULCA + ["telemetry", "disable"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+    assert disabled.returncode == 0
+    assert "enabled: false" in disabled.stdout
+
+
+def test_telemetry_policy_doc_names_default_off_and_forbidden_fields():
+    policy = (ROOT / "docs" / "platform" / "telemetry-policy.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "off by default" in policy.lower()
+    assert "DO_NOT_TRACK=1" in policy
+    assert "prompts" in policy
+    assert "image paths" in policy
+    assert "image bytes" in policy
+    assert "API keys" in policy
+    assert "mcp_tool_called" in policy


### PR DESCRIPTION
## Summary
- add privacy-safe runtime telemetry client with default-off behavior
- add `vulca telemetry status|enable|disable|reset-id`
- instrument CLI command-group events and FastMCP tool calls without recording arguments
- document telemetry policy, allowed fields, forbidden fields, and usage runbook

## Privacy boundary
- `DO_NOT_TRACK=1` overrides all opt-in sources
- unknown event properties are dropped by allowlist
- prompts, image paths, image bytes, API keys, stack traces, and local identifiers are not emitted
- sink failures and missing endpoints are silent no-ops

Closes #37

## Validation
- `PYTHONPATH=src python3.11 -m pytest tests/test_telemetry.py tests/test_mcp_server.py tests/test_package.py -q`
- `PYTHONPATH=src python3.11 -m pytest tests/test_cli_create_output.py::TestCreateOutputParam::test_create_help_has_output_param -q`
- `python3.11 -m ruff check src/vulca/telemetry.py src/vulca/cli.py src/vulca/mcp_server.py tests/test_telemetry.py`
- `python3.11 -m py_compile src/vulca/telemetry.py src/vulca/cli.py src/vulca/mcp_server.py tests/test_telemetry.py`
- `git diff --cached --check`
- `gemini-agent diff-review --stdin` -> pass
