### PR TITLE
chore: converge SDK links on renamed repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ blank_issues_enabled: false
 
 contact_links:
   - name: "💬 Discussions — open-ended questions, roadmap, usage help"
-    url: https://github.com/vulca-org/vulca/discussions
+    url: https://github.com/vulca-org/vulca-visual-control-sdk/discussions
     about: "For anything that isn't a concrete bug or a concrete feature request. Usage questions, design discussions, 'is this the right tool for X' questions — all welcome here."
 
   - name: "🔒 Security issues"
-    url: https://github.com/vulca-org/vulca/blob/master/SECURITY.md
+    url: https://github.com/vulca-org/vulca-visual-control-sdk/blob/master/SECURITY.md
     about: "Please email yuhaorui48@gmail.com privately — do NOT open a public issue. See SECURITY.md for scope + SLA."

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -24,7 +24,7 @@ Vulca is an agent's hands and eyes, not its brain. Before proposing, confirm:
 - [ ] The feature exposes information through an **MCP tool schema** or a **skill body**, not by embedding logic in Python SDK code.
 - [ ] There's a **dogfooding story** — a real cultural-evaluation workflow this unblocks. Describe it in one sentence.
 
-If any of these are "no" but you still think the feature belongs, open a **[Discussion](https://github.com/vulca-org/vulca/discussions)** first instead of an issue — we'll figure out together whether it's an agent-layer or SDK-layer concern.
+If any of these are "no" but you still think the feature belongs, open a **[Discussion](https://github.com/vulca-org/vulca-visual-control-sdk/discussions)** first instead of an issue — we'll figure out together whether it's an agent-layer or SDK-layer concern.
 
 See [CONTRIBUTING.md § Anti-patterns](../../CONTRIBUTING.md#anti-patterns--what-will-not-be-merged) for what won't be merged.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 [![PyPI](https://img.shields.io/pypi/v/vulca.svg)](https://pypi.org/project/vulca/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://pypi.org/project/vulca/)
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/vulca-org/vulca/blob/master/LICENSE)
-[![CI](https://github.com/vulca-org/vulca/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/vulca-org/vulca/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/vulca-org/vulca-visual-control-sdk/blob/master/LICENSE)
+[![CI](https://github.com/vulca-org/vulca-visual-control-sdk/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/vulca-org/vulca-visual-control-sdk/actions/workflows/ci.yml)
 [![MCP Tools](https://img.shields.io/badge/MCP_tools-current-blueviolet.svg)](https://github.com/vulca-org/vulca-plugin)
 
 **Vulca turns fuzzy visual intent into controlled creative production.**
@@ -115,7 +115,7 @@ pip install vulca[mcp]==0.23.1
 # Install the /decompose skill:
 mkdir -p ~/.claude/skills/decompose
 curl -o ~/.claude/skills/decompose/SKILL.md \
-  "https://raw.githubusercontent.com/vulca-org/vulca/v0.23.1/.claude/skills/decompose/SKILL.md?utm_source=github-readme&utm_medium=oss&utm_campaign=refresh-2026-05-11"
+  "https://raw.githubusercontent.com/vulca-org/vulca-visual-control-sdk/v0.23.1/.claude/skills/decompose/SKILL.md?utm_source=github-readme&utm_medium=oss&utm_campaign=refresh-2026-05-11"
 ```
 
 <p align="center">
@@ -528,7 +528,7 @@ From an agent: `/evaluate` calls the `evaluate_artwork` MCP tool and returns evo
 
 ## Support
 
-- **Issues:** [github.com/vulca-org/vulca/issues](https://github.com/vulca-org/vulca/issues) — bug reports, feature requests, workflow needs that should become a skill
+- **Issues:** [github.com/vulca-org/vulca-visual-control-sdk/issues](https://github.com/vulca-org/vulca-visual-control-sdk/issues) — bug reports, feature requests, workflow needs that should become a skill
 - **Plugin:** [vulca-org/vulca-plugin](https://github.com/vulca-org/vulca-plugin) — version-tracked with the SDK; install in Claude Code, Gemini CLI, or Codex Desktop/CLI
 - **Web platform:** [vulcaart.art](https://vulcaart.art) and [vulca-platform](https://github.com/yha9806/vulca-platform) — the deployed demo/site and platform workspace
 - **Skill source:** [`.claude/skills/decompose/SKILL.md`](.claude/skills/decompose/SKILL.md) in this repo — the only source of truth for the `/decompose` flow

--- a/docs/agent-native-workflow.md
+++ b/docs/agent-native-workflow.md
@@ -185,6 +185,6 @@ That manifest is the contract. The agent reads it, re-authors the plan, and runs
 
 ## Links
 
-- Repo: https://github.com/vulca-org/vulca
+- Repo: https://github.com/vulca-org/vulca-visual-control-sdk
 - Social showcase: Post #1 (Bieber Coachella) and Post #2 (Trump Butler) linked from the README
 - Pipeline entry point: `scripts/claude_orchestrated_pipeline.py`

--- a/docs/apple-silicon-mps-comfyui-guide.md
+++ b/docs/apple-silicon-mps-comfyui-guide.md
@@ -156,9 +156,9 @@ Replace the default SDXL VAE with [`madebyollin/sdxl-vae-fp16-fix`](https://hugg
 
 During this investigation we also fixed three VULCA bugs that compound with MPS issues:
 
-- **ANCHOR hallucination** — Prompt section headers `[CANVAS ANCHOR]` caused SDXL to paint literal ship anchors. Renamed to `[CANVAS]`. ([`b168178`](https://github.com/vulca-org/vulca/commit/b168178))
-- **CLIP token overflow** — Structured prompts (120+ tokens) exceed SDXL CLIP's 77-token limit. Added CLIP-aware flat prompt mode for ComfyUI. ([`74f9952`](https://github.com/vulca-org/vulca/commit/74f9952))
-- **Background keying** — Luminance keying on background layers made white paper transparent. Added `content_type` guard. ([`42e0e3d`](https://github.com/vulca-org/vulca/commit/42e0e3d))
+- **ANCHOR hallucination** — Prompt section headers `[CANVAS ANCHOR]` caused SDXL to paint literal ship anchors. Renamed to `[CANVAS]`. ([`b168178`](https://github.com/vulca-org/vulca-visual-control-sdk/commit/b168178))
+- **CLIP token overflow** — Structured prompts (120+ tokens) exceed SDXL CLIP's 77-token limit. Added CLIP-aware flat prompt mode for ComfyUI. ([`74f9952`](https://github.com/vulca-org/vulca-visual-control-sdk/commit/74f9952))
+- **Background keying** — Luminance keying on background layers made white paper transparent. Added `content_type` guard. ([`42e0e3d`](https://github.com/vulca-org/vulca-visual-control-sdk/commit/42e0e3d))
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,9 +133,9 @@ select = ["E9", "F63", "F7", "F82"]
 
 [project.urls]
 Homepage = "https://vulcaart.art"
-Documentation = "https://github.com/vulca-org/vulca"
-Repository = "https://github.com/vulca-org/vulca"
-Issues = "https://github.com/vulca-org/vulca/issues"
+Documentation = "https://github.com/vulca-org/vulca-visual-control-sdk"
+Repository = "https://github.com/vulca-org/vulca-visual-control-sdk"
+Issues = "https://github.com/vulca-org/vulca-visual-control-sdk/issues"
 
 [project.scripts]
 vulca = "vulca.cli:main"

--- a/scripts/tapes/create-demo.tape
+++ b/scripts/tapes/create-demo.tape
@@ -65,6 +65,6 @@ Type '#     → Add a poem (题画诗) for poetry-calligraphy-painting-seal harm
 Enter
 Sleep 3s
 
-Type "# github.com/vulca-org/vulca"
+Type "# github.com/vulca-org/vulca-visual-control-sdk"
 Enter
 Sleep 2s

--- a/scripts/tapes/full-demo.tape
+++ b/scripts/tapes/full-demo.tape
@@ -100,6 +100,6 @@ Enter
 Sleep 2s
 
 # === Outro ===
-Type "# github.com/vulca-org/vulca | pip install vulca"
+Type "# github.com/vulca-org/vulca-visual-control-sdk | pip install vulca"
 Enter
 Sleep 3s

--- a/src/vulca/_image.py
+++ b/src/vulca/_image.py
@@ -46,7 +46,7 @@ async def load_image_base64(image: str) -> tuple[str, str]:
 
     # URL
     if image.startswith(("http://", "https://")):
-        headers = {"User-Agent": "VULCA/0.3 (https://github.com/vulca-org/vulca)"}
+        headers = {"User-Agent": "VULCA/0.3 (https://github.com/vulca-org/vulca-visual-control-sdk)"}
         async with httpx.AsyncClient(timeout=30, follow_redirects=True, headers=headers) as client:
             resp = await client.get(image)
             resp.raise_for_status()


### PR DESCRIPTION
## Summary

- update current README badges, download/support links, package project URLs, and issue-template links to `vulca-org/vulca-visual-control-sdk`
- align active workflow/demo references and the HTTP user-agent with the renamed repository
- preserve dated publications, historical plans/specs, social assets, and version-verification snapshots as historical evidence

## Why

GitHub now names the SDK repository `vulca-org/vulca-visual-control-sdk`. The former `vulca-org/vulca` URL still redirects to the renamed repository, but current maintained surfaces should use the canonical URL directly instead of depending on that redirect.

## Validation

- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_image_resolve.py tests/test_package.py -q` (52 passed)
- `/opt/homebrew/bin/ruff check src/vulca/_image.py`
- built wheel and sdist with `python3.11 -m build`; verified all three generated `Project-URL` metadata entries
- parsed `pyproject.toml` and issue-template YAML and asserted the expected canonical URLs
- confirmed maintained files have no boundary-safe `vulca-org/vulca` references while `vulca-org/vulca-plugin` remains untouched
- confirmed representative canonical links return HTTP 200 and the former repository URL returns HTTP 301 to the new slug
- `git diff --check`
