### PR TITLE
docs: align visual agent plugin references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "vulca",
   "version": "0.23.1",
   "description": "Vulca visual-control plugin for Claude Code: discovery, brainstorm, spec, plan, evaluate, and decompose workflows backed by Vulca MCP tools.",
-  "homepage": "https://github.com/vulca-org/vulca-plugin",
+  "homepage": "https://github.com/vulca-org/vulca-visual-agent-plugin",
   "license": "Apache-2.0",
   "author": {
     "name": "Vulca maintainers",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ ruff check src/ tests/      # narrow rule set (E9/F63/F7/F82) in v0.17.x — exp
 
 The MCP surface lives in `src/vulca/mcp_server.py`. Any new tool must:
 - have a schema test under `tests/test_mcp_parity.py` or `tests/test_mcp_new_tools.py`
-- be listed in the plugin manifest at `vulca-org/vulca-plugin`
+- be listed in the plugin manifest at `vulca-org/vulca-visual-agent-plugin`
 - survive a live ship-gate (see `docs/superpowers/plans/*.md`)
 
 ## Anti-patterns — what will NOT be merged

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://pypi.org/project/vulca/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/vulca-org/vulca-visual-control-sdk/blob/master/LICENSE)
 [![CI](https://github.com/vulca-org/vulca-visual-control-sdk/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/vulca-org/vulca-visual-control-sdk/actions/workflows/ci.yml)
-[![MCP Tools](https://img.shields.io/badge/MCP_tools-current-blueviolet.svg)](https://github.com/vulca-org/vulca-plugin)
+[![MCP Tools](https://img.shields.io/badge/MCP_tools-current-blueviolet.svg)](https://github.com/vulca-org/vulca-visual-agent-plugin)
 
 **Vulca turns fuzzy visual intent into controlled creative production.**
 
@@ -99,7 +99,7 @@ Claude: 5 layers extracted — each person figure isolated, drapery and ground s
 
 ```bash
 pip install vulca[mcp]==0.23.1
-claude plugin install vulca-org/vulca-plugin
+claude plugin install vulca-org/vulca-visual-agent-plugin
 ```
 
 Then in Claude Code: `> /decompose /path/to/your_image.jpg`
@@ -529,7 +529,7 @@ From an agent: `/evaluate` calls the `evaluate_artwork` MCP tool and returns evo
 ## Support
 
 - **Issues:** [github.com/vulca-org/vulca-visual-control-sdk/issues](https://github.com/vulca-org/vulca-visual-control-sdk/issues) — bug reports, feature requests, workflow needs that should become a skill
-- **Plugin:** [vulca-org/vulca-plugin](https://github.com/vulca-org/vulca-plugin) — version-tracked with the SDK; install in Claude Code, Gemini CLI, or Codex Desktop/CLI
+- **Plugin:** [vulca-org/vulca-visual-agent-plugin](https://github.com/vulca-org/vulca-visual-agent-plugin) — version-tracked with the SDK; install in Claude Code, Gemini CLI, or Codex Desktop/CLI
 - **Web platform:** [vulcaart.art](https://vulcaart.art) and [vulca-platform](https://github.com/yha9806/vulca-platform) — the deployed demo/site and platform workspace
 - **Skill source:** [`.claude/skills/decompose/SKILL.md`](.claude/skills/decompose/SKILL.md) in this repo — the only source of truth for the `/decompose` flow
 - **Skill source:** [`.claude/skills/visual-discovery/SKILL.md`](.claude/skills/visual-discovery/SKILL.md) — **`/visual-discovery`** explores fuzzy visual intent into taste profile, culture analysis, direction cards, and proposal-ready handoff. It is text/artifact-first: mock sketch records are allowed by default; real provider sketch generation requires explicit opt-in. The Codex/Superpowers mirror lives at [`.agents/skills/visual-discovery/SKILL.md`](.agents/skills/visual-discovery/SKILL.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,9 +22,9 @@ timelines are best-effort, not contractual.
 
 **In scope:**
 - The `vulca` PyPI package.
-- The `vulca-org/vulca-plugin` Claude Code / Cursor plugin.
+- The `vulca-org/vulca-visual-agent-plugin` Claude Code / Cursor plugin.
 - Any shipped MCP tool schema + `.claude/skills/*`.
-- **Workflow JSON shipped inside the `vulca` package or `vulca-org/vulca-plugin`** (e.g., bundled ComfyUI graph templates, skill-embedded example workflows) — regressions or RCE-class issues here are our responsibility.
+- **Workflow JSON shipped inside the `vulca` package or `vulca-org/vulca-visual-agent-plugin`** (e.g., bundled ComfyUI graph templates, skill-embedded example workflows) — regressions or RCE-class issues here are our responsibility.
 - **Workflow JSON synthesized by Vulca skills / MCP tools** from agent input (e.g., a `/decompose` or `/visual-plan` tool writing a workflow that a prompt-injected VLM response could influence) — the synthesis path is in scope even when the execution environment is local.
 
 **Out of scope:**

--- a/docs/platform/manual-review-checklist.md
+++ b/docs/platform/manual-review-checklist.md
@@ -57,27 +57,22 @@ Verify:
 
 ## Codex Manual Gate
 
-The installed local CLI in this environment is `codex-cli 0.121.0` and exposes:
+The installed ChatGPT desktop CLI in this environment is `codex-cli 0.144.2` and exposes:
 
 ```bash
-codex marketplace add .
+codex plugin marketplace add .
+codex plugin add vulca --marketplace vulca-visual-agent-plugin
 ```
 
-Official docs currently show:
+Then restart Codex and verify:
 
-```bash
-codex plugin marketplace add ./local-marketplace-root
-```
-
-Use whichever form the installed CLI supports, then restart Codex and verify:
-
-- `Vulca Plugins` appears as a marketplace source;
+- `Vulca Visual Agent Plugin` appears as a marketplace source;
 - `Vulca` appears as an installable plugin;
 - bundled skills are visible after install;
 - `vulca-mcp` can start;
 - plugin copy does not contain scaffold placeholder markers.
 
-Do not state that official Codex public publishing has opened until OpenAI's docs change from "coming soon."
+Before public submission, confirm the publisher has Apps Management write access and a verified developer or business identity, then use `https://platform.openai.com/plugins`.
 
 ## Redraw Gate
 

--- a/docs/platform/openai-codex-mcp-guide.md
+++ b/docs/platform/openai-codex-mcp-guide.md
@@ -36,13 +36,12 @@ python scripts/sync_plugin.py
 python scripts/sync_plugin.py --check
 ```
 
-Observed local CLI:
+Current Codex CLI:
 
 ```bash
-codex marketplace add .
+codex plugin marketplace add .
+codex plugin add vulca --marketplace vulca-visual-agent-plugin
 ```
-
-Official docs may show a `codex plugin marketplace add` form. Verify the installed CLI before publishing install instructions.
 
 ## Local Codex MCP
 

--- a/docs/platform/release-readiness-status.md
+++ b/docs/platform/release-readiness-status.md
@@ -1,13 +1,13 @@
 # Platform Release Readiness Status
 
 **Status:** Working release gate summary
-**Last updated:** 2026-05-01
+**Last updated:** 2026-07-16
 
 ## Current Claims We Can Make
 
 - Vulca has a Claude plugin package shape at the repository root: `.claude-plugin/plugin.json`, `.mcp.json`, and `skills/`.
-- Vulca has a repo-local Codex plugin package for validation: `plugins/vulca/.codex-plugin/plugin.json`, `plugins/vulca/.mcp.json`, and `plugins/vulca/skills/`.
-- Codex can be documented as a plugin plus MCP target; official public Codex plugin publishing should remain future-facing until OpenAI opens that flow.
+- Vulca has a public Git-backed Codex marketplace source at `vulca-org/vulca-visual-agent-plugin`, backed by `plugins/vulca/.codex-plugin/plugin.json`, `plugins/vulca/.mcp.json`, and `plugins/vulca/skills/`.
+- Codex can be documented as a plugin plus MCP target. OpenAI's plugin submission portal is available, but a directory listing must not be claimed before submission and acceptance.
 - ChatGPT can be documented as a remote MCP app/prototype target with a remote-safe streamable HTTP entry point, `vulca-mcp-remote`.
 - Google/Gemini can be documented as a provider path now, with ADK / Vertex Agent Engine later.
 - Redraw is an advanced workflow today. v0.22 target-aware mask refinement is merged, but polished `/inpaint` or `/redraw-layer` promotion remains gated on real-image dogfood evidence.
@@ -22,13 +22,16 @@
 
 ## Verification Evidence
 
-Run in `master` on 2026-05-01:
+Revalidated from the public Plugin repository after the rename on 2026-07-15:
 
 ```bash
-/opt/homebrew/bin/codex marketplace add .
+/Applications/ChatGPT.app/Contents/Resources/codex plugin marketplace add vulca-org/vulca-visual-agent-plugin
+/Applications/ChatGPT.app/Contents/Resources/codex plugin add vulca --marketplace vulca-visual-agent-plugin
 ```
 
-Observed: added marketplace `vulca-plugins` from this worktree.
+Observed with an isolated `CODEX_HOME`: added marketplace `vulca-visual-agent-plugin` from public GitHub and installed `vulca@vulca-visual-agent-plugin` version `0.23.1`.
+
+The following Claude evidence remains the historical 2026-05-01 validation record:
 
 ```bash
 /Users/yhryzy/.local/bin/claude plugin validate .
@@ -103,7 +106,7 @@ Observed: 14 passed.
 ## Manual Gates Remaining
 
 - Optional: run a full interactive `claude --plugin-dir .` session if you want UI-level confirmation beyond `plugin validate` and non-interactive skill discovery.
-- Optional: open Codex UI and confirm the newly added `vulca-plugins` marketplace source appears as expected.
+- Optional: open Codex UI and confirm the `vulca-visual-agent-plugin` marketplace source and `vulca` plugin appear as expected.
 - Deploy `vulca-mcp-remote` behind HTTPS/auth/logging before connecting it to ChatGPT developer mode from a public URL.
 - For ChatGPT App resubmission, the public privacy policy route is live at
   `https://vulcaart.art/chatgpt-app-privacy`; complete

--- a/docs/product/platform-distribution-realtime-brief.md
+++ b/docs/product/platform-distribution-realtime-brief.md
@@ -47,8 +47,8 @@ Current official facts:
 
 - Codex plugins can package skills, MCP servers, agents, hooks, commands, and assets with a `.codex-plugin/plugin.json` manifest.
 - Codex has an official plugin marketplace and app directory experience, plus local and Git-backed marketplace sources.
-- OpenAI's Codex plugin docs currently describe official public plugin publishing as coming soon; repo-local and personal marketplace testing are the practical near-term path.
-- The observed local CLI exposes `codex marketplace add <source>` for adding a marketplace root.
+- OpenAI provides a public plugin submission portal for skills-only, app-only, and combined app-plus-skills plugins; submitters need the required organization role and a verified developer or business identity.
+- The current CLI exposes `codex plugin marketplace add <source>` for adding a marketplace root, followed by `codex plugin add <plugin> --marketplace <name>` to install a plugin.
 - Codex can add MCP servers with `codex mcp add <name> --url <server-url>` or via `~/.codex/config.toml`.
 - ChatGPT developer mode is a beta feature with full MCP client access for read and write tools.
 - ChatGPT developer mode supports SSE and streaming HTTP remote MCP servers.
@@ -70,7 +70,7 @@ Vulca implication:
 
 - Ship a Codex repo-local marketplace package first, using `plugins/vulca/.codex-plugin/plugin.json`.
 - Keep the Codex plugin self-contained with copied skill files and a local `vulca-mcp` declaration.
-- Treat official Codex public listing as a later submission path until OpenAI's public plugin publishing flow is available.
+- Use the OpenAI plugin submission portal only after the local marketplace package and any MCP-backed app surface pass their respective review gates.
 - Ship a local MCP guide for Codex alongside the plugin, using the existing `vulca-mcp` server.
 - Design a remote MCP profile separately, with a conservative default tool set and explicit approval guidance.
 - Recommended initial remote MCP allowlist: `list_traditions`, `get_tradition_guide`, `search_traditions`, `compose_prompt_from_design`, `evaluate_artwork`, `view_image` only after path/security handling is settled.

--- a/plugins/vulca/.codex-plugin/plugin.json
+++ b/plugins/vulca/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Vulca maintainers",
     "url": "https://github.com/vulca-org"
   },
-  "homepage": "https://github.com/vulca-org/vulca-plugin",
-  "repository": "https://github.com/vulca-org/vulca-plugin",
+  "homepage": "https://github.com/vulca-org/vulca-visual-agent-plugin",
+  "repository": "https://github.com/vulca-org/vulca-visual-agent-plugin",
   "license": "Apache-2.0",
   "keywords": [
     "visual-control",
@@ -28,7 +28,7 @@
       "Write",
       "MCP"
     ],
-    "websiteURL": "https://github.com/vulca-org/vulca-plugin",
+    "websiteURL": "https://github.com/vulca-org/vulca-visual-agent-plugin",
     "defaultPrompt": [
       "Run Vulca visual discovery for this visual idea and produce direction cards.",
       "Decompose this image into semantic layers and summarize what can be edited.",


### PR DESCRIPTION
## Summary

- Update the canonical SDK's active Plugin references to `vulca-org/vulca-visual-agent-plugin` after the completed repository rename.
- Align Claude and nested Codex manifest metadata with the new public Plugin URL.
- Replace obsolete Codex marketplace commands and stale public-publishing guidance in current platform documentation.
- Refresh the working release-readiness status with the verified public Git-backed Codex installation path.

## Why

The Plugin repository rename and public distribution migration are complete and governance records the state as `rename-verified`. The SDK default branch still points users and maintainers to the legacy Plugin slug in active installation, support, security, and platform-distribution surfaces.

## Changes

- Update active Plugin links and installation references in:
  - `README.md`;
  - `CONTRIBUTING.md`;
  - `SECURITY.md`;
  - `.claude-plugin/plugin.json`;
  - `plugins/vulca/.codex-plugin/plugin.json`.
- Update current platform guidance to the two-step Codex flow:
  - `codex plugin marketplace add <source>`;
  - `codex plugin add vulca --marketplace vulca-visual-agent-plugin`.
- Point submission guidance to `https://platform.openai.com/plugins` while retaining the acceptance boundary: no directory-listing claim before submission and approval.
- Refresh `docs/platform/release-readiness-status.md` to record the successful public GitHub marketplace/install verification for version `0.23.1`.

Historical dated plans, specifications, CHANGELOG entries, and captured v0.16.1 verification artifacts retain the repository name that was true when those records were created. GitHub's old URL redirect preserves access; rewriting those records would erase chronology rather than repair a current user surface.

## Validation

- Remote `master` and the prepared branch base are identical at `dcb6a399673cf373c839a53e5074575da108e4bc`; no base drift exists.
- Both changed JSON manifests parse successfully.
- `python3 scripts/sync_plugin.py --check`: `plugin package is in sync`.
- `pytest tests/test_sync_plugin.py -q`: `4 passed`.
- `ruff check src/ tests/`: passed.
- Active-surface scan across README, contribution/security docs, Plugin manifests, `docs/platform`, and the current platform-distribution brief found no legacy `vulca-org/vulca-plugin` slug or obsolete `codex marketplace` command.
- `git diff --check`: passed.

## Scope and impact

This PR is documentation and manifest metadata only. It does **not**:

- modify SDK runtime code or the MCP tool surface;
- change the SDK or Plugin version;
- publish a package, tag, or Release;
- rewrite historical migration records;
- merge the prepared Profile or legacy Platform updates;
- by itself claim the overall Plugin migration state `development-restored`.
