### PR TITLE
Resolve initial CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/vulca/studio/phases/evaluate.py
+++ b/src/vulca/studio/phases/evaluate.py
@@ -31,7 +31,7 @@ class EvaluatePhase:
         import hashlib
 
         round_num = len(brief.generations) + 1
-        seed = hashlib.md5(f"{brief.session_id}:{round_num}".encode()).digest()
+        seed = hashlib.sha256(f"{brief.session_id}:{round_num}".encode()).digest()
 
         # Brief completeness drives base score: 0.45 (empty) → 0.70 (complete)
         completeness = sum([

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -272,6 +272,8 @@ class TestCreateWithMock:
     def test_acreate_uses_env_url(self):
         """acreate reads VULCA_API_URL from environment."""
         import os
+        from urllib.parse import urlsplit
+
         import httpx
 
         mock_response = MagicMock()
@@ -293,7 +295,7 @@ class TestCreateWithMock:
 
             # Verify the URL was used
             call_args = mock_client.post.call_args
-            assert "custom.api.com" in call_args[0][0]
+            assert urlsplit(call_args[0][0]).hostname == "custom.api.com"
         finally:
             if orig:
                 os.environ["VULCA_API_URL"] = orig


### PR DESCRIPTION
## What changed

- grants SDK CI only read access to repository contents
- replaces MD5 with SHA-256 for deterministic mock-score seeding
- verifies the configured API endpoint by parsing and comparing its hostname

## Why

The first organization-wide CodeQL scan found one missing workflow-permissions alert, one weak-hash alert, and one incomplete URL-substring validation alert. All three can be resolved directly without suppressions.

## Impact

Mock evaluation remains deterministic, URL behavior remains covered, and CI follows least privilege. No public API changes.

## Validation

- workflow YAML parsed successfully
- Ruff passed on the changed Python files
- `tests/test_evaluate.py`: 24 passed
- organization CodeQL will re-run on the pull request
