### PR TITLE
feat(layers): add experimental OpenRaster round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added the advanced/experimental, non-generative `openraster-roundtrip`
+  Effect Pack for flat full-canvas Artifact/manifest layer interchange with
+  Krita-compatible OpenRaster files.
+- Added public Python, CLI, and MCP import/export surfaces plus per-layer and
+  composite hash evidence in `openraster-roundtrip.json`.
+- Added strict archive, XML, canvas, path-containment, decoded-workload, and
+  no-overwrite validation. Unsupported transforms, blend modes, and nested
+  stacks fail explicitly.
+
+### Verification
+
+- 71 related Artifact/manifest/alpha/CLI/OpenRaster tests pass.
+- Dedicated clean-clone OpenRaster suite: 11 passed.
+- Local seed baseline and tiny training/eval gates pass.
+- `ruff check src tests` and `git diff --check` pass.
+
 ## v0.23.1 (2026-05-11)
 
 Patch release for the NB2/Gemini masked-edit adapter.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ vulca create "intent" -t tradition --provider mock|gemini|nb2|openai|openai-resp
 vulca evaluate image.png -t tradition --mode strict|reference|fusion
   --skills brand,audience,trend  # extra commercial scoring skills
 
-# Layers (all 14 subcommands)
+# Layers
 vulca layers analyze image.png
 vulca layers split image.png -o dir --mode extract|regenerate|sam
 vulca layers redraw dir --layer name -i "instruction"
@@ -397,7 +397,8 @@ vulca layers lock dir --layer name
 vulca layers merge dir --layers a,b --name merged
 vulca layers duplicate dir --layer name
 vulca layers composite dir -o output.png
-vulca layers export dir -o output.psd
+vulca layers export dir --format ora -o layers.ora
+vulca layers import-ora layers.ora imported-dir
 vulca layers evaluate dir -t tradition
 vulca layers regenerate dir --provider gemini
 
@@ -443,6 +444,8 @@ weights = vulca.get_weights("chinese_xieyi")
 ```
 
 </details>
+
+OpenRaster interchange is an advanced/experimental, non-generative Effect Pack. See [the round-trip contract](docs/effect-packs/openraster-roundtrip.md) for protected invariants, evidence, and first-version limits.
 
 <details>
 <summary>Architecture</summary>

--- a/docs/effect-packs/openraster-roundtrip.md
+++ b/docs/effect-packs/openraster-roundtrip.md
@@ -1,0 +1,82 @@
+# OpenRaster round-trip Effect Pack
+
+Status: advanced / experimental
+
+`openraster-roundtrip` is a non-generative engineering Effect Pack. It moves an existing VULCA layered Artifact or manifest through a flat OpenRaster (`.ora`) document and back without invoking an image provider. It does not claim an artistic improvement and does not score visual quality.
+
+The implementation follows the OpenRaster 0.0.6 file-layout and layer-stack contracts: `mimetype` is the first uncompressed ZIP member, `stack.xml` lists the uppermost layer first, and the archive includes `mergedimage.png`, `Thumbnails/thumbnail.png`, and per-layer PNG files under `data/`.
+
+## Protected invariants
+
+A no-edit round trip protects:
+
+- canvas width and height;
+- layer count and stable IDs;
+- names and bottom-to-top ordering;
+- visibility, opacity, and supported blend modes;
+- every layer's decoded RGBA pixels;
+- the recomposited RGBA result.
+
+The importer records the source ORA hash, source document hash, before/after layer RGBA hashes, and composite hashes in `openraster-roundtrip.json`. Provider, model, prompt, seed, cost, and latency are recorded as `not_applicable` because no model is called.
+
+## SDK-native contract mapping
+
+This pack does not import Layered Redraw's `project.json`, design-plan, preset, history, or editor-server contracts. The SDK remains authoritative:
+
+| Concern | Canonical SDK contract | OpenRaster representation |
+|---|---|---|
+| project document | existing Artifact V3 or `manifest.json` | `vulca.json` is an interchange sidecar only, never a second project database |
+| layer identity | `LayerInfo.id` | sidecar ID, `vulca:id` XML extension, and reversible name marker |
+| layer order | unique `LayerInfo.z_index` values | topmost-first `stack.xml`; imported order is written back into the existing z-index slots |
+| editable pixels | full-canvas RGBA layer PNG | `data/*.png` |
+| visibility / opacity / blend | existing `LayerInfo` fields | standard ORA layer attributes |
+| output and evidence | existing manifest plus operation evidence | new canonical `manifest.json`, `composite.png`, and `openraster-roundtrip.json` |
+
+The sidecar retains additional source metadata for comparison, but the protected first-version contract is intentionally limited to the invariants listed above. Artifact-only fields outside the current manifest writer are not claimed as round-trip invariants.
+
+## API
+
+```python
+from vulca.layers import export_openraster, import_openraster
+
+export_result = export_openraster("artwork", "artwork/layers.ora")
+import_result = import_openraster("artwork/layers.ora", "artwork-from-ora")
+```
+
+Import always targets a new directory. It validates into a sibling staging directory and promotes the result with one atomic rename; it never overwrites an existing destination.
+
+Rollback is therefore non-destructive: retain the source artwork and ORA, discard the newly imported directory if review fails, and use `openraster-roundtrip.json` to identify changed layers before promotion into any later workflow.
+
+## CLI
+
+```text
+vulca layers export artwork --format ora --output artwork/layers.ora
+vulca layers import-ora artwork/layers.ora artwork-from-ora
+```
+
+The same operations are available through the `layers_export` and `layers_import_openraster` MCP tools.
+
+## Deliberate first-version limits
+
+- flat stacks only; nested ORA groups are rejected;
+- 1–256 full-canvas PNG layers at `x=0`, `y=0`;
+- at most 256 million decoded layer-pixels per operation;
+- VULCA spatial transforms must be baked or resolved before export;
+- supported blend modes are `normal`, `multiply`, `screen`, `overlay`, `soft_light`, `darken`, `lighten`, `color_dodge`, and `color_burn`;
+- layer additions or deletions are rejected while a VULCA sidecar is present;
+- if an editor removes the sidecar and XML extension attribute, the reversible ID marker in each layer name is the final identity fallback.
+
+Malformed paths, project-external source layer files, duplicate ZIP entries, encrypted/unsupported compression, oversized members, excessive decoded workloads, DTD/entity declarations, canvas drift, unsupported composite operations, duplicate IDs, and an existing import destination are rejected before project promotion.
+
+## Evidence status
+
+- deterministic contract tests cover clean round-trip, one-layer pixel edits, layer reorder, sidecar degradation, editor-renamed internal paths, and hostile archives;
+- the existing six-layer `assets/demo/v2/layers-split` repository artwork is exercised as the non-synthetic round-trip fixture;
+- provider/model execution is not applicable to this engineering-only pack;
+- current claim: local implementation and contract tests pass;
+- not claimed here: SDK merge, SDK release, plugin availability, artistic improvement, or human acceptance.
+
+OpenRaster references:
+
+- <https://www.openraster.org/baseline/file-layout-spec.html>
+- <https://www.openraster.org/baseline/layer-stack-spec.html>

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -227,10 +227,14 @@ def main(argv: list[str] | None = None) -> None:
     layers_composite.add_argument("artwork_dir", help="Directory with layer PNGs + manifest")
     layers_composite.add_argument("--output", "-o", default="", help="Output path")
 
-    layers_export = layers_sub.add_parser("export", help="Export layers as PSD/PNG")
+    layers_export = layers_sub.add_parser("export", help="Export layers as PNG, legacy PSD directory, or OpenRaster")
     layers_export.add_argument("artwork_dir", help="Directory with layers")
-    layers_export.add_argument("--format", "-f", default="png", choices=["png", "psd"])
+    layers_export.add_argument("--format", "-f", default="png", choices=["png", "psd", "ora"])
     layers_export.add_argument("--output", "-o", default="", help="Output path")
+
+    layers_import_ora = layers_sub.add_parser("import-ora", help="Import a flat OpenRaster archive into a new artwork directory")
+    layers_import_ora.add_argument("archive", help="Input .ora archive")
+    layers_import_ora.add_argument("output_dir", help="New destination directory (must not already exist)")
 
     layers_regen = layers_sub.add_parser("regenerate", help="Regenerate unified image from composite")
     layers_regen.add_argument("artwork_dir", help="Directory with composite + layers")
@@ -1708,10 +1712,15 @@ def _cmd_layers(args: argparse.Namespace) -> None:
 
     elif args.layers_command == "export":
         from vulca.layers.edit import load_artwork
-        from vulca.layers.export import export_psd
+        from vulca.layers.export import export_openraster, export_psd
         from vulca.layers.composite import composite_layers
         artwork = load_artwork(args.artwork_dir)
-        if args.format == "psd":
+        if args.format == "ora":
+            import json
+            out = args.output or str(Path(args.artwork_dir) / "layers.ora")
+            result = export_openraster(args.artwork_dir, out)
+            print(json.dumps(result, indent=2))
+        elif args.format == "psd":
             out = args.output or str(Path(args.artwork_dir) / "layers.psd")
             import json
             manifest_path = Path(args.artwork_dir) / "manifest.json"
@@ -1735,6 +1744,12 @@ def _cmd_layers(args: argparse.Namespace) -> None:
                 width = height = 1024
             composite_layers(artwork.layers, width=width, height=height, output_path=out)
             print(f"  Exported PNG: {out}")
+
+    elif args.layers_command == "import-ora":
+        import json
+        from vulca.layers.export import import_openraster
+        result = import_openraster(args.archive, args.output_dir)
+        print(json.dumps(result, indent=2))
 
     elif args.layers_command == "add":
         from vulca.layers.manifest import load_manifest

--- a/src/vulca/layers/__init__.py
+++ b/src/vulca/layers/__init__.py
@@ -5,7 +5,7 @@ from vulca.layers.split import split_extract, split_regenerate, split_vlm, crop_
 from vulca.layers.palette_mask import split_palette, build_palette_mask_prompt, decode_palette_mask
 from vulca.layers.composite import composite_layers
 from vulca.layers.blend import blend_normal, blend_screen, blend_multiply, blend_overlay, blend_soft_light, blend_darken, blend_lighten, blend_color_dodge, blend_color_burn, blend_layers
-from vulca.layers.export import export_psd
+from vulca.layers.export import OpenRasterError, export_openraster, export_psd, import_openraster
 from vulca.layers.manifest import write_manifest as write_manifest_v2, load_manifest, MANIFEST_VERSION
 from vulca.layers.artifact import write_artifact_v3, load_artifact_v3, ARTIFACT_VERSION
 from vulca.layers.mask import build_color_mask, apply_mask_to_image
@@ -48,7 +48,7 @@ __all__ = [
     "blend_normal", "blend_screen", "blend_multiply",
     "blend_overlay", "blend_soft_light", "blend_darken", "blend_lighten",
     "blend_color_dodge", "blend_color_burn", "blend_layers",
-    "export_psd",
+    "export_psd", "export_openraster", "import_openraster", "OpenRasterError",
     "write_manifest_v2", "load_manifest", "MANIFEST_VERSION",
     "write_artifact_v3", "load_artifact_v3", "ARTIFACT_VERSION",
     "build_color_mask", "apply_mask_to_image",

--- a/src/vulca/layers/export.py
+++ b/src/vulca/layers/export.py
@@ -1,12 +1,882 @@
-"""Export layered artwork to PSD and PNG directory (V2)."""
+"""Export layered artwork to delivery and interchange formats."""
 from __future__ import annotations
 
+import base64
+import binascii
+import hashlib
+import io
 import json
-from pathlib import Path
+import math
+import os
+import re
+import shutil
+import tempfile
+import zipfile
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from xml.etree import ElementTree as ET
 
 from PIL import Image
 
-from vulca.layers.types import LayerResult
+from vulca.layers.artifact import load_artifact_v3
+from vulca.layers.blend import blend_layers
+from vulca.layers.manifest import write_manifest
+from vulca.layers.transform import needs_transform
+from vulca.layers.types import LayerInfo, LayerResult
+
+
+OPENRASTER_MIMETYPE = b"image/openraster"
+OPENRASTER_VERSION = "0.0.6"
+OPENRASTER_SIDECAR = "vulca.json"
+OPENRASTER_EVIDENCE = "openraster-roundtrip.json"
+OPENRASTER_OPERATION_VERSION = "openraster-roundtrip/1"
+VULCA_ORA_NS = "https://vulcaart.art/ns/openraster/1.0"
+MAX_ARCHIVE_ENTRIES = 4096
+MAX_ARCHIVE_UNCOMPRESSED_BYTES = 512 * 1024 * 1024
+MAX_MEMBER_BYTES = 256 * 1024 * 1024
+MAX_XML_BYTES = 4 * 1024 * 1024
+MAX_SIDECAR_BYTES = 8 * 1024 * 1024
+MAX_CANVAS_DIMENSION = 32768
+MAX_CANVAS_PIXELS = 100_000_000
+MAX_TOTAL_LAYER_PIXELS = 256_000_000
+MAX_LAYERS = 256
+_LAYER_MARKER_RE = re.compile(r"^(?P<name>.*) \[vulca-id:(?P<id>[A-Za-z0-9_-]+)\]$", re.DOTALL)
+
+_BLEND_TO_ORA = {
+    "normal": "svg:src-over",
+    "multiply": "svg:multiply",
+    "screen": "svg:screen",
+    "overlay": "svg:overlay",
+    "soft_light": "svg:soft-light",
+    "darken": "svg:darken",
+    "lighten": "svg:lighten",
+    "color_dodge": "svg:color-dodge",
+    "color_burn": "svg:color-burn",
+}
+_ORA_TO_BLEND = {value: key for key, value in _BLEND_TO_ORA.items()}
+
+
+class OpenRasterError(ValueError):
+    """Raised when an ORA file cannot preserve the VULCA layer contract."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _rgba_sha256(image: Image.Image) -> str:
+    rgba = image.convert("RGBA")
+    prefix = f"RGBA:{rgba.width}x{rgba.height}\0".encode("ascii")
+    return _sha256_bytes(prefix + rgba.tobytes())
+
+
+def _png_bytes(image: Image.Image) -> bytes:
+    output = io.BytesIO()
+    image.save(output, format="PNG", compress_level=6)
+    return output.getvalue()
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def _checked_text(value: object, *, field: str, default: str = "", limit: int = 32768) -> str:
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise OpenRasterError(f"{field} must be text")
+    if len(value) > limit or any(ord(char) < 32 and char not in "\t\n\r" for char in value):
+        raise OpenRasterError(f"{field} contains unsupported control characters or is too long")
+    return value
+
+
+def _checked_identifier(value: object, *, field: str = "layer id") -> str:
+    identifier = _checked_text(value, field=field, limit=512)
+    if not identifier:
+        raise OpenRasterError(f"{field} must not be empty")
+    return identifier
+
+
+def _encode_layer_id(layer_id: str) -> str:
+    return base64.urlsafe_b64encode(layer_id.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _decode_layer_id(encoded: str) -> str:
+    padding = "=" * (-len(encoded) % 4)
+    try:
+        payload = base64.b64decode(encoded + padding, altchars=b"-_", validate=True)
+        return _checked_identifier(payload.decode("utf-8"))
+    except (binascii.Error, UnicodeDecodeError, OpenRasterError) as exc:
+        raise OpenRasterError("Invalid VULCA layer-id marker in OpenRaster layer name") from exc
+
+
+def _marked_layer_name(name: str, layer_id: str) -> str:
+    return f"{name} [vulca-id:{_encode_layer_id(layer_id)}]"
+
+
+def _split_marked_layer_name(name: str) -> tuple[str, str | None]:
+    match = _LAYER_MARKER_RE.fullmatch(name)
+    if not match:
+        return name, None
+    return match.group("name"), _decode_layer_id(match.group("id"))
+
+
+def _checked_canvas(width: object, height: object) -> tuple[int, int]:
+    if (
+        not isinstance(width, int)
+        or isinstance(width, bool)
+        or not isinstance(height, int)
+        or isinstance(height, bool)
+        or width <= 0
+        or height <= 0
+        or width > MAX_CANVAS_DIMENSION
+        or height > MAX_CANVAS_DIMENSION
+        or width * height > MAX_CANVAS_PIXELS
+    ):
+        raise OpenRasterError("Canvas dimensions are invalid or exceed the OpenRaster safety limit")
+    return width, height
+
+
+def _canvas_from_document(document: dict) -> tuple[int, int]:
+    canvas = document.get("canvas")
+    if isinstance(canvas, dict):
+        return _checked_canvas(canvas.get("width"), canvas.get("height"))
+    return _checked_canvas(document.get("width"), document.get("height"))
+
+
+def _load_png(payload: bytes, *, field: str, expected_size: tuple[int, int] | None = None) -> Image.Image:
+    if len(payload) > MAX_MEMBER_BYTES:
+        raise OpenRasterError(f"{field} exceeds the per-file safety limit")
+    try:
+        with Image.open(io.BytesIO(payload)) as opened:
+            if opened.format != "PNG":
+                raise OpenRasterError(f"{field} must be a PNG image")
+            opened.load()
+            image = opened.convert("RGBA")
+    except OpenRasterError:
+        raise
+    except Exception as exc:
+        raise OpenRasterError(f"{field} is not a readable PNG: {exc}") from exc
+    if expected_size is not None and image.size != expected_size:
+        raise OpenRasterError(f"{field} has canvas {image.size}; expected {expected_size}")
+    return image
+
+
+def _document_fields(document: dict) -> dict:
+    warnings = document.get("warnings", [])
+    if not isinstance(warnings, list) or not all(isinstance(item, str) for item in warnings):
+        warnings = []
+    return {
+        "split_mode": str(document.get("split_mode", document.get("generation_mode", "")) or ""),
+        "generation_path": str(document.get("generation_path", "") or ""),
+        "layerability": str(document.get("layerability", "") or ""),
+        "partial": bool(document.get("partial", False)),
+        "warnings": warnings,
+        "tradition": str(document.get("tradition", "") or ""),
+    }
+
+
+def _source_layers(artwork_dir: str) -> tuple[list[LayerResult], int, int, Path, dict]:
+    artwork_root = Path(artwork_dir).expanduser().resolve()
+    if not artwork_root.is_dir():
+        raise OpenRasterError(f"VULCA artwork directory does not exist: {artwork_root}")
+    artwork = load_artifact_v3(str(artwork_root))
+    document_path = Path(artwork.manifest_path).resolve()
+    try:
+        document_path.relative_to(artwork_root)
+    except ValueError as exc:
+        raise OpenRasterError("Canonical VULCA document must be inside the artwork directory") from exc
+    try:
+        document_bytes = document_path.read_bytes()
+        document = json.loads(document_bytes.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise OpenRasterError(f"Cannot read canonical VULCA document: {exc}") from exc
+    if not isinstance(document, dict):
+        raise OpenRasterError("Canonical VULCA document must contain a JSON object")
+    width, height = _canvas_from_document(document)
+    layers = sorted(artwork.layers, key=lambda layer: layer.info.z_index)
+    if not 1 <= len(layers) <= MAX_LAYERS:
+        raise OpenRasterError(f"OpenRaster export requires 1-{MAX_LAYERS} layers")
+    if width * height * len(layers) > MAX_TOTAL_LAYER_PIXELS:
+        raise OpenRasterError("OpenRaster layer workload exceeds the decoded-pixel safety limit")
+    ids = [_checked_identifier(layer.info.id) for layer in layers]
+    if len(ids) != len(set(ids)):
+        raise OpenRasterError("Layer ids must be unique before OpenRaster export")
+    z_indices = [layer.info.z_index for layer in layers]
+    if any(not isinstance(value, int) or isinstance(value, bool) for value in z_indices):
+        raise OpenRasterError("Layer z_index values must be integers")
+    if len(z_indices) != len(set(z_indices)):
+        raise OpenRasterError("Layer z_index values must be unique before OpenRaster export")
+    for layer in layers:
+        image_path = Path(layer.image_path).resolve()
+        try:
+            image_path.relative_to(artwork_root)
+        except ValueError as exc:
+            raise OpenRasterError(
+                f"Layer {layer.info.id} image must stay inside the artwork directory"
+            ) from exc
+        if not image_path.is_file():
+            raise OpenRasterError(f"Layer {layer.info.id} image does not exist: {image_path}")
+        layer.image_path = str(image_path)
+    return layers, width, height, document_path, {"raw": document_bytes, "data": document}
+
+
+def _source_layer_record(layer: LayerResult, *, src: str, canvas: tuple[int, int]) -> tuple[dict, bytes]:
+    info = layer.info
+    _checked_text(info.name, field=f"layer {info.id} name", limit=1024)
+    if info.blend_mode not in _BLEND_TO_ORA:
+        raise OpenRasterError(f"Layer {info.id} uses unsupported blend mode {info.blend_mode!r}")
+    if not isinstance(info.opacity, (int, float)) or isinstance(info.opacity, bool) or not math.isfinite(info.opacity):
+        raise OpenRasterError(f"Layer {info.id} opacity must be a finite number")
+    if not 0.0 <= float(info.opacity) <= 1.0:
+        raise OpenRasterError(f"Layer {info.id} opacity must be between 0 and 1")
+    if needs_transform(info):
+        raise OpenRasterError(
+            f"Layer {info.id} has a VULCA spatial transform; the first ORA Effect Pack only accepts full-canvas layers"
+        )
+    image_path = Path(layer.image_path)
+    try:
+        png_payload = image_path.read_bytes()
+    except OSError as exc:
+        raise OpenRasterError(f"Cannot read layer {info.id}: {exc}") from exc
+    image = _load_png(png_payload, field=f"layer {info.id}", expected_size=canvas)
+    record = {
+        "id": info.id,
+        "name": info.name,
+        "src": src,
+        "z_index": info.z_index,
+        "visible": bool(info.visible),
+        "opacity": float(info.opacity),
+        "blend_mode": info.blend_mode,
+        "rgba_sha256": _rgba_sha256(image),
+        "png_sha256": _sha256_bytes(png_payload),
+        "metadata": asdict(info),
+        "scores": _safe_scores(layer.scores),
+    }
+    return record, png_payload
+
+
+def export_openraster(artwork_dir: str, output_path: str) -> dict:
+    """Export a canonical VULCA Artifact/manifest as a flat OpenRaster archive.
+
+    The source artwork is never mutated. Layer PNGs must already be full-canvas
+    and must not use VULCA spatial transforms. Stable ids are stored in a VULCA
+    sidecar, an XML extension attribute, and a reversible layer-name marker so
+    that editors which discard unknown extension files still preserve identity.
+    """
+    layers, width, height, document_path, document = _source_layers(artwork_dir)
+    canvas = (width, height)
+    records: list[dict] = []
+    png_members: dict[str, bytes] = {}
+    for position, layer in enumerate(layers):
+        id_digest = hashlib.sha256(layer.info.id.encode("utf-8")).hexdigest()[:12]
+        src = f"data/layer-{position:04d}-{id_digest}.png"
+        record, png_payload = _source_layer_record(layer, src=src, canvas=canvas)
+        records.append(record)
+        png_members[src] = png_payload
+
+    composite = blend_layers(layers, width=width, height=height)
+    composite_payload = _png_bytes(composite)
+    thumbnail = composite.copy()
+    thumbnail.thumbnail((256, 256), Image.Resampling.LANCZOS)
+    thumbnail_payload = _png_bytes(thumbnail)
+
+    ET.register_namespace("vulca", VULCA_ORA_NS)
+    image_root = ET.Element("image", {"version": OPENRASTER_VERSION, "w": str(width), "h": str(height)})
+    stack = ET.SubElement(image_root, "stack")
+    for record in reversed(records):  # OpenRaster lists the uppermost layer first.
+        layer_element = ET.SubElement(
+            stack,
+            "layer",
+            {
+                "name": _marked_layer_name(record["name"], record["id"]),
+                "src": record["src"],
+                "x": "0",
+                "y": "0",
+                "opacity": format(record["opacity"], ".12g"),
+                "visibility": "visible" if record["visible"] else "hidden",
+                "composite-op": _BLEND_TO_ORA[record["blend_mode"]],
+            },
+        )
+        layer_element.set(f"{{{VULCA_ORA_NS}}}id", record["id"])
+    stack_payload = ET.tostring(image_root, encoding="utf-8", xml_declaration=True)
+
+    sidecar = {
+        "schema_version": 1,
+        "kind": "vulca-openraster-roundtrip",
+        "operation_version": OPENRASTER_OPERATION_VERSION,
+        "created_at": _now(),
+        "source_document": document_path.name,
+        "source_document_sha256": _sha256_bytes(document["raw"]),
+        "canvas": {"width": width, "height": height},
+        "source_composite_rgba_sha256": _rgba_sha256(composite),
+        "source_layer_order_bottom_to_top": [record["id"] for record in records],
+        "document_fields": _document_fields(document["data"]),
+        "provider": "not_applicable",
+        "model": "not_applicable",
+        "prompt": "not_applicable",
+        "seed": "not_applicable",
+        "cost": "not_applicable",
+        "latency": "not_applicable",
+        "layers": records,
+    }
+    sidecar_payload = json.dumps(sidecar, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8")
+
+    destination = Path(output_path).expanduser().resolve()
+    if destination.suffix.lower() != ".ora":
+        raise OpenRasterError("OpenRaster output_path must end in .ora")
+    if destination.exists() and destination.is_dir():
+        raise OpenRasterError("OpenRaster output_path points to a directory")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent)
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        with zipfile.ZipFile(temporary, "w", allowZip64=True) as archive:
+            mimetype_info = zipfile.ZipInfo("mimetype")
+            mimetype_info.compress_type = zipfile.ZIP_STORED
+            archive.writestr(mimetype_info, OPENRASTER_MIMETYPE)
+            archive.writestr("stack.xml", stack_payload, compress_type=zipfile.ZIP_DEFLATED)
+            for src, payload in png_members.items():
+                archive.writestr(src, payload, compress_type=zipfile.ZIP_DEFLATED)
+            archive.writestr("mergedimage.png", composite_payload, compress_type=zipfile.ZIP_DEFLATED)
+            archive.writestr("Thumbnails/thumbnail.png", thumbnail_payload, compress_type=zipfile.ZIP_DEFLATED)
+            archive.writestr(OPENRASTER_SIDECAR, sidecar_payload, compress_type=zipfile.ZIP_DEFLATED)
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+    return {
+        "schema_version": 1,
+        "operation": "openraster-export",
+        "operation_version": OPENRASTER_OPERATION_VERSION,
+        "export_path": str(destination),
+        "ora_sha256": _sha256_file(destination),
+        "source_document": str(document_path),
+        "source_document_sha256": sidecar["source_document_sha256"],
+        "canvas": sidecar["canvas"],
+        "layer_count": len(records),
+        "source_composite_rgba_sha256": sidecar["source_composite_rgba_sha256"],
+        "provider": "not_applicable",
+        "model": "not_applicable",
+        "prompt": "not_applicable",
+        "seed": "not_applicable",
+        "cost": "not_applicable",
+        "latency": "not_applicable",
+        "layers": [
+            {"id": record["id"], "rgba_sha256": record["rgba_sha256"], "png_sha256": record["png_sha256"]}
+            for record in records
+        ],
+    }
+
+
+def _validate_archive_members(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    infos = archive.infolist()
+    if not infos or len(infos) > MAX_ARCHIVE_ENTRIES:
+        raise OpenRasterError("OpenRaster archive has an invalid number of entries")
+    if infos[0].filename != "mimetype" or infos[0].compress_type != zipfile.ZIP_STORED:
+        raise OpenRasterError("OpenRaster mimetype must be the first uncompressed archive entry")
+    by_name: dict[str, zipfile.ZipInfo] = {}
+    total_size = 0
+    for info in infos:
+        name = info.filename
+        if name in by_name:
+            raise OpenRasterError(f"OpenRaster archive contains duplicate entry {name!r}")
+        if not name or "\x00" in name or "\\" in name or name.startswith("/"):
+            raise OpenRasterError(f"Unsafe OpenRaster archive path {name!r}")
+        stripped = name[:-1] if name.endswith("/") else name
+        parts = stripped.split("/")
+        path = PurePosixPath(stripped)
+        if not stripped or any(part in {"", ".", ".."} for part in parts) or path.is_absolute() or ":" in parts[0]:
+            raise OpenRasterError(f"Unsafe OpenRaster archive path {name!r}")
+        if info.flag_bits & 0x1:
+            raise OpenRasterError("Encrypted OpenRaster entries are not supported")
+        if info.compress_type not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}:
+            raise OpenRasterError("OpenRaster entries must use STORED or DEFLATED compression")
+        if info.file_size > MAX_MEMBER_BYTES:
+            raise OpenRasterError(f"OpenRaster entry {name!r} exceeds the per-file safety limit")
+        total_size += info.file_size
+        if total_size > MAX_ARCHIVE_UNCOMPRESSED_BYTES:
+            raise OpenRasterError("OpenRaster archive exceeds the uncompressed safety limit")
+        by_name[name] = info
+    return by_name
+
+
+def _read_member(
+    archive: zipfile.ZipFile,
+    members: dict[str, zipfile.ZipInfo],
+    name: str,
+    *,
+    limit: int = MAX_MEMBER_BYTES,
+) -> bytes:
+    info = members.get(name)
+    if info is None or info.is_dir():
+        raise OpenRasterError(f"Required OpenRaster entry is missing: {name}")
+    if info.file_size > limit:
+        raise OpenRasterError(f"OpenRaster entry {name!r} exceeds its safety limit")
+    payload = archive.read(info)
+    if len(payload) != info.file_size:
+        raise OpenRasterError(f"OpenRaster entry {name!r} is truncated")
+    return payload
+
+
+def _parse_stack_xml(payload: bytes) -> tuple[int, int, list[dict]]:
+    if len(payload) > MAX_XML_BYTES:
+        raise OpenRasterError("stack.xml exceeds the XML safety limit")
+    upper = payload.upper()
+    if b"<!DOCTYPE" in upper or b"<!ENTITY" in upper:
+        raise OpenRasterError("stack.xml must not contain DTD or entity declarations")
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise OpenRasterError(f"stack.xml is invalid XML: {exc}") from exc
+    if _local_name(root.tag) != "image":
+        raise OpenRasterError("stack.xml root element must be image")
+    try:
+        width = int(root.get("w", ""))
+        height = int(root.get("h", ""))
+    except ValueError as exc:
+        raise OpenRasterError("stack.xml canvas dimensions must be integers") from exc
+    width, height = _checked_canvas(width, height)
+    stacks = [child for child in list(root) if _local_name(child.tag) == "stack"]
+    if len(stacks) != 1:
+        raise OpenRasterError("The first ORA Effect Pack requires exactly one root stack")
+    entries: list[dict] = []
+    for child in list(stacks[0]):
+        if _local_name(child.tag) != "layer":
+            raise OpenRasterError("The first ORA Effect Pack supports flat layer stacks only")
+        src = _checked_text(child.get("src"), field="OpenRaster layer src", limit=2048)
+        if not src.startswith("data/"):
+            raise OpenRasterError("OpenRaster layer src must point inside data/")
+        try:
+            x = int(child.get("x", "0"))
+            y = int(child.get("y", "0"))
+            opacity = float(child.get("opacity", "1"))
+        except ValueError as exc:
+            raise OpenRasterError("OpenRaster layer offset or opacity is invalid") from exc
+        if x != 0 or y != 0:
+            raise OpenRasterError("The first ORA Effect Pack requires full-canvas layers at x=0, y=0")
+        if not math.isfinite(opacity) or not 0.0 <= opacity <= 1.0:
+            raise OpenRasterError("OpenRaster layer opacity must be between 0 and 1")
+        visibility = child.get("visibility", "visible")
+        if visibility not in {"visible", "hidden"}:
+            raise OpenRasterError(f"Unsupported OpenRaster visibility {visibility!r}")
+        composite_op = child.get("composite-op", "svg:src-over")
+        if composite_op not in _ORA_TO_BLEND:
+            raise OpenRasterError(f"Unsupported OpenRaster composite-op {composite_op!r}")
+        marked_name = _checked_text(child.get("name", ""), field="OpenRaster layer name", limit=2048)
+        display_name, marker_id = _split_marked_layer_name(marked_name)
+        extension_id = child.get(f"{{{VULCA_ORA_NS}}}id")
+        if extension_id is not None:
+            extension_id = _checked_identifier(extension_id, field="OpenRaster vulca:id")
+        if marker_id and extension_id and marker_id != extension_id:
+            raise OpenRasterError("OpenRaster layer id marker conflicts with vulca:id")
+        entries.append(
+            {
+                "src": src,
+                "name": display_name,
+                "marker_id": marker_id,
+                "extension_id": extension_id,
+                "visible": visibility == "visible",
+                "opacity": opacity,
+                "blend_mode": _ORA_TO_BLEND[composite_op],
+            }
+        )
+    if not 1 <= len(entries) <= MAX_LAYERS:
+        raise OpenRasterError(f"OpenRaster import requires 1-{MAX_LAYERS} flat layers")
+    if width * height * len(entries) > MAX_TOTAL_LAYER_PIXELS:
+        raise OpenRasterError("OpenRaster layer workload exceeds the decoded-pixel safety limit")
+    sources = [entry["src"] for entry in entries]
+    if len(sources) != len(set(sources)):
+        raise OpenRasterError("OpenRaster layer src values must be unique")
+    return width, height, entries
+
+
+def _parse_sidecar(payload: bytes, *, canvas: tuple[int, int]) -> dict:
+    if len(payload) > MAX_SIDECAR_BYTES:
+        raise OpenRasterError("VULCA OpenRaster sidecar exceeds the JSON safety limit")
+    try:
+        sidecar = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise OpenRasterError(f"VULCA OpenRaster sidecar is invalid JSON: {exc}") from exc
+    if not isinstance(sidecar, dict) or sidecar.get("kind") != "vulca-openraster-roundtrip":
+        raise OpenRasterError("VULCA OpenRaster sidecar has an unsupported contract")
+    if sidecar.get("schema_version") != 1:
+        raise OpenRasterError("VULCA OpenRaster sidecar schema version is unsupported")
+    if sidecar.get("operation_version") != OPENRASTER_OPERATION_VERSION:
+        raise OpenRasterError("VULCA OpenRaster sidecar operation version is unsupported")
+    sidecar_canvas = sidecar.get("canvas", {})
+    if not isinstance(sidecar_canvas, dict) or _checked_canvas(
+        sidecar_canvas.get("width"), sidecar_canvas.get("height")
+    ) != canvas:
+        raise OpenRasterError("VULCA sidecar canvas conflicts with stack.xml")
+    layers = sidecar.get("layers")
+    if not isinstance(layers, list) or not layers:
+        raise OpenRasterError("VULCA sidecar layers must be a non-empty array")
+    by_src: dict[str, dict] = {}
+    by_id: dict[str, dict] = {}
+    ids: set[str] = set()
+    for item in layers:
+        if not isinstance(item, dict):
+            raise OpenRasterError("VULCA sidecar layer entries must be objects")
+        layer_id = _checked_identifier(item.get("id"))
+        src = _checked_text(item.get("src"), field=f"sidecar src for {layer_id}", limit=2048)
+        if layer_id in ids or src in by_src:
+            raise OpenRasterError("VULCA sidecar layer ids and src values must be unique")
+        z_index = item.get("z_index")
+        if not isinstance(z_index, int) or isinstance(z_index, bool):
+            raise OpenRasterError(f"VULCA sidecar z_index for {layer_id} must be an integer")
+        _checked_text(item.get("name", ""), field=f"sidecar name for {layer_id}", limit=1024)
+        if not isinstance(item.get("visible"), bool):
+            raise OpenRasterError(f"VULCA sidecar visibility for {layer_id} must be boolean")
+        opacity = item.get("opacity")
+        if (
+            not isinstance(opacity, (int, float))
+            or isinstance(opacity, bool)
+            or not math.isfinite(opacity)
+            or not 0.0 <= float(opacity) <= 1.0
+        ):
+            raise OpenRasterError(f"VULCA sidecar opacity for {layer_id} must be between 0 and 1")
+        if item.get("blend_mode") not in _BLEND_TO_ORA:
+            raise OpenRasterError(f"VULCA sidecar blend mode for {layer_id} is unsupported")
+        rgba_hash = item.get("rgba_sha256")
+        if not isinstance(rgba_hash, str) or re.fullmatch(r"[0-9a-f]{64}", rgba_hash) is None:
+            raise OpenRasterError(f"VULCA sidecar pixel hash for {layer_id} is invalid")
+        if not isinstance(item.get("metadata", {}), dict):
+            raise OpenRasterError(f"VULCA sidecar metadata for {layer_id} must be an object")
+        ids.add(layer_id)
+        by_src[src] = item
+        by_id[layer_id] = item
+    source_order = sidecar.get("source_layer_order_bottom_to_top")
+    if (
+        not isinstance(source_order, list)
+        or not all(isinstance(value, str) for value in source_order)
+        or len(source_order) != len(ids)
+        or set(source_order) != ids
+    ):
+        raise OpenRasterError("VULCA sidecar source layer order does not match its layers")
+    for field in ("source_document_sha256", "source_composite_rgba_sha256"):
+        value = sidecar.get(field)
+        if not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None:
+            raise OpenRasterError(f"VULCA sidecar {field} is invalid")
+    document_fields = sidecar.get("document_fields", {})
+    if not isinstance(document_fields, dict):
+        raise OpenRasterError("VULCA sidecar document_fields must be an object")
+    document_warnings = document_fields.get("warnings", [])
+    if not isinstance(document_warnings, list) or not all(isinstance(value, str) for value in document_warnings):
+        raise OpenRasterError("VULCA sidecar document warnings must be an array of strings")
+    sidecar["layers_by_src"] = by_src
+    sidecar["layers_by_id"] = by_id
+    return sidecar
+
+
+def _safe_scores(value: object) -> dict[str, float]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, float] = {}
+    for key, score in value.items():
+        if isinstance(key, str) and isinstance(score, (int, float)) and not isinstance(score, bool) and math.isfinite(score):
+            result[key] = float(score)
+    return result
+
+
+def _metadata_text(metadata: dict, key: str, *, default: str = "", limit: int = 32768) -> str:
+    return _checked_text(metadata.get(key, default), field=f"sidecar metadata {key}", default=default, limit=limit)
+
+
+def _layer_info_from_import(
+    metadata: object,
+    *,
+    layer_id: str,
+    name: str,
+    z_index: int,
+    visible: bool,
+    opacity: float,
+    blend_mode: str,
+) -> LayerInfo:
+    source = metadata if isinstance(metadata, dict) else {}
+    dominant = source.get("dominant_colors", [])
+    if not isinstance(dominant, list) or not all(isinstance(value, str) for value in dominant):
+        dominant = []
+    else:
+        dominant = [_checked_text(value, field="sidecar dominant color", limit=128) for value in dominant[:256]]
+    generation_round = source.get("generation_round", 0)
+    if not isinstance(generation_round, int) or isinstance(generation_round, bool):
+        generation_round = 0
+    area_pct = source.get("area_pct", 0.0)
+    if not isinstance(area_pct, (int, float)) or isinstance(area_pct, bool) or not math.isfinite(area_pct):
+        area_pct = 0.0
+    parent_layer_id = source.get("parent_layer_id")
+    if parent_layer_id is not None:
+        parent_layer_id = _checked_identifier(parent_layer_id, field="sidecar metadata parent_layer_id")
+    bbox = source.get("bbox") if isinstance(source.get("bbox"), dict) else None
+    content_bbox = source.get("content_bbox") if isinstance(source.get("content_bbox"), dict) else None
+    return LayerInfo(
+        name=_checked_text(name, field=f"layer {layer_id} name", limit=1024),
+        description=_metadata_text(source, "description"),
+        z_index=z_index,
+        id=layer_id,
+        content_type=_metadata_text(source, "content_type", default="background", limit=256),
+        dominant_colors=dominant,
+        regeneration_prompt=_metadata_text(source, "regeneration_prompt", limit=131072),
+        visible=visible,
+        blend_mode=blend_mode,
+        bg_color=_metadata_text(source, "bg_color", default="white", limit=64),
+        locked=bool(source.get("locked", False)) if isinstance(source.get("locked", False), bool) else False,
+        bbox=bbox,
+        x=0.0,
+        y=0.0,
+        width=100.0,
+        height=100.0,
+        rotation=0.0,
+        content_bbox=content_bbox,
+        tradition_role=_metadata_text(source, "tradition_role", limit=1024),
+        opacity=opacity,
+        status=_metadata_text(source, "status", limit=128),
+        weakness=_metadata_text(source, "weakness", limit=32768),
+        generation_round=generation_round,
+        position=_metadata_text(source, "position", limit=4096),
+        coverage=_metadata_text(source, "coverage", limit=4096),
+        semantic_path=_metadata_text(source, "semantic_path", limit=4096),
+        parent_layer_id=parent_layer_id,
+        quality_status=_metadata_text(source, "quality_status", default="detected", limit=128),
+        area_pct=float(area_pct),
+    )
+
+
+def import_openraster(input_path: str, output_dir: str) -> dict:
+    """Import a flat ORA archive into a new canonical VULCA manifest directory.
+
+    The destination must not exist. Import is staged beside the destination and
+    promoted with one atomic rename only after the archive, pixels, ids, canvas,
+    and metadata have been validated.
+    """
+    source = Path(input_path).expanduser().resolve()
+    if not source.is_file():
+        raise OpenRasterError(f"OpenRaster input does not exist: {source}")
+    destination = Path(output_dir).expanduser().resolve()
+    if destination.exists():
+        raise OpenRasterError(f"OpenRaster import destination already exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    ora_sha256 = _sha256_file(source)
+
+    try:
+        archive = zipfile.ZipFile(source, "r")
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise OpenRasterError(f"Cannot open OpenRaster archive: {exc}") from exc
+
+    with archive:
+        members = _validate_archive_members(archive)
+        if _read_member(archive, members, "mimetype", limit=64) != OPENRASTER_MIMETYPE:
+            raise OpenRasterError("OpenRaster mimetype content is invalid")
+        width, height, top_to_bottom = _parse_stack_xml(
+            _read_member(archive, members, "stack.xml", limit=MAX_XML_BYTES)
+        )
+        canvas = (width, height)
+        merged = _load_png(
+            _read_member(archive, members, "mergedimage.png"),
+            field="mergedimage.png",
+            expected_size=canvas,
+        )
+        thumbnail = _load_png(
+            _read_member(archive, members, "Thumbnails/thumbnail.png"),
+            field="Thumbnails/thumbnail.png",
+        )
+        if thumbnail.width > 256 or thumbnail.height > 256:
+            raise OpenRasterError("OpenRaster thumbnail must not exceed 256x256")
+
+        sidecar = None
+        warnings: list[str] = []
+        if OPENRASTER_SIDECAR in members:
+            sidecar = _parse_sidecar(
+                _read_member(archive, members, OPENRASTER_SIDECAR, limit=MAX_SIDECAR_BYTES),
+                canvas=canvas,
+            )
+        else:
+            warnings.append("VULCA sidecar was not preserved; semantic metadata is reduced to stable id markers")
+
+        resolved_top_to_bottom: list[dict] = []
+        for entry in top_to_bottom:
+            expected = sidecar["layers_by_src"].get(entry["src"]) if sidecar else None
+            candidate_ids = [value for value in (entry["marker_id"], entry["extension_id"]) if value]
+            if len(set(candidate_ids)) > 1:
+                raise OpenRasterError(f"Layer {entry['src']} has conflicting stable VULCA ids")
+            if sidecar and expected is None and candidate_ids:
+                expected = sidecar["layers_by_id"].get(candidate_ids[0])
+                if expected is not None:
+                    warnings.append(
+                        f"Layer {candidate_ids[0]} changed its internal OpenRaster path; metadata matched by stable id"
+                    )
+            if expected is not None:
+                candidate_ids.append(_checked_identifier(expected.get("id")))
+            if not candidate_ids or len(set(candidate_ids)) != 1:
+                raise OpenRasterError(f"Layer {entry['src']} does not preserve one stable VULCA id")
+            entry["id"] = candidate_ids[0]
+            entry["expected"] = expected
+            resolved_top_to_bottom.append(entry)
+
+        ids = [entry["id"] for entry in resolved_top_to_bottom]
+        if len(ids) != len(set(ids)):
+            raise OpenRasterError("Imported OpenRaster layer ids must be unique")
+        if sidecar:
+            expected_ids = {_checked_identifier(item.get("id")) for item in sidecar["layers"]}
+            if set(ids) != expected_ids or len(ids) != len(sidecar["layers"]):
+                raise OpenRasterError("OpenRaster layer count or stable ids drifted from the VULCA sidecar")
+
+        bottom_to_top = list(reversed(resolved_top_to_bottom))
+        if sidecar:
+            z_slots = sorted(int(item.get("z_index")) for item in sidecar["layers"])
+            if len(z_slots) != len(set(z_slots)):
+                raise OpenRasterError("VULCA sidecar z_index values must be unique")
+        else:
+            z_slots = list(range(len(bottom_to_top)))
+
+        stage = Path(tempfile.mkdtemp(prefix=f".{destination.name}.import-", dir=destination.parent))
+        try:
+            (stage / "layers").mkdir(parents=True, exist_ok=True)
+            layer_results: list[LayerResult] = []
+            layer_files: dict[str, str] = {}
+            evidence_layers: list[dict] = []
+            for position, (entry, z_index) in enumerate(zip(bottom_to_top, z_slots, strict=True)):
+                payload = _read_member(archive, members, entry["src"])
+                image = _load_png(payload, field=entry["src"], expected_size=canvas)
+                layer_id = entry["id"]
+                expected = entry["expected"]
+                expected_hash = expected.get("rgba_sha256") if isinstance(expected, dict) else None
+                actual_hash = _rgba_sha256(image)
+                filename = f"layers/{position:04d}_{hashlib.sha256(layer_id.encode('utf-8')).hexdigest()[:12]}.png"
+                image.save(stage / Path(filename), format="PNG", compress_level=6)
+                metadata = expected.get("metadata") if isinstance(expected, dict) else {}
+                info = _layer_info_from_import(
+                    metadata,
+                    layer_id=layer_id,
+                    name=entry["name"],
+                    z_index=z_index,
+                    visible=entry["visible"],
+                    opacity=entry["opacity"],
+                    blend_mode=entry["blend_mode"],
+                )
+                scores = _safe_scores(expected.get("scores")) if isinstance(expected, dict) else {}
+                result = LayerResult(info=info, image_path=str(stage / Path(filename)), scores=scores)
+                layer_results.append(result)
+                layer_files[layer_id] = filename
+                metadata_changed = None
+                if isinstance(expected, dict):
+                    metadata_changed = any(
+                        (
+                            entry["name"] != expected.get("name"),
+                            entry["visible"] != expected.get("visible", True),
+                            not math.isclose(entry["opacity"], float(expected.get("opacity", 1.0)), abs_tol=1e-12),
+                            entry["blend_mode"] != expected.get("blend_mode"),
+                            z_index != expected.get("z_index"),
+                        )
+                    )
+                evidence_layers.append(
+                    {
+                        "id": layer_id,
+                        "file": filename,
+                        "before_rgba_sha256": expected_hash,
+                        "after_rgba_sha256": actual_hash,
+                        "pixels_changed": None if expected_hash is None else actual_hash != expected_hash,
+                        "metadata_changed": metadata_changed,
+                    }
+                )
+
+            document_fields = sidecar.get("document_fields", {}) if sidecar else {}
+            if not isinstance(document_fields, dict):
+                document_fields = {}
+            write_manifest(
+                [layer.info for layer in layer_results],
+                output_dir=str(stage),
+                width=width,
+                height=height,
+                split_mode=str(document_fields.get("split_mode", "") or ""),
+                generation_path=str(document_fields.get("generation_path", "") or ""),
+                layerability=str(document_fields.get("layerability", "") or ""),
+                partial=bool(document_fields.get("partial", False)),
+                warnings=list(document_fields.get("warnings", [])) + warnings,
+                layer_files=layer_files,
+                tradition=str(document_fields.get("tradition", "") or ""),
+            )
+            imported_composite = blend_layers(layer_results, width=width, height=height)
+            imported_composite.save(stage / "composite.png", format="PNG", compress_level=6)
+            composite_hash = _rgba_sha256(imported_composite)
+            expected_composite_hash = sidecar.get("source_composite_rgba_sha256") if sidecar else None
+            archive_merged_hash = _rgba_sha256(merged)
+            imported_order = [layer.info.id for layer in layer_results]
+            expected_order = sidecar.get("source_layer_order_bottom_to_top") if sidecar else None
+            order_changed = None if expected_order is None else imported_order != expected_order
+            no_edit_roundtrip = bool(
+                sidecar
+                and not order_changed
+                and all(item["pixels_changed"] is False for item in evidence_layers)
+                and all(item["metadata_changed"] is False for item in evidence_layers)
+                and composite_hash == expected_composite_hash
+                and archive_merged_hash == expected_composite_hash
+            )
+            evidence = {
+                "schema_version": 1,
+                "operation": "openraster-import",
+                "operation_version": OPENRASTER_OPERATION_VERSION,
+                "created_at": _now(),
+                "source_ora": source.name,
+                "ora_sha256": ora_sha256,
+                "source_document_sha256": sidecar.get("source_document_sha256") if sidecar else None,
+                "canvas": {"width": width, "height": height},
+                "provider": "not_applicable",
+                "model": "not_applicable",
+                "prompt": "not_applicable",
+                "seed": "not_applicable",
+                "cost": "not_applicable",
+                "latency": "not_applicable",
+                "warnings": warnings,
+                "layers": evidence_layers,
+                "verification": {
+                    "status": "verified-no-edit" if no_edit_roundtrip else "edited-or-metadata-degraded",
+                    "no_edit_roundtrip": no_edit_roundtrip,
+                    "layer_order_changed": order_changed,
+                    "source_composite_rgba_sha256": expected_composite_hash,
+                    "imported_composite_rgba_sha256": composite_hash,
+                    "archive_mergedimage_rgba_sha256": archive_merged_hash,
+                    "archive_mergedimage_matches_imported": archive_merged_hash == composite_hash,
+                },
+            }
+            (stage / OPENRASTER_EVIDENCE).write_text(
+                json.dumps(evidence, ensure_ascii=False, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            stage.replace(destination)
+        except Exception:
+            shutil.rmtree(stage, ignore_errors=True)
+            raise
+
+    return {
+        "schema_version": 1,
+        "operation": "openraster-import",
+        "operation_version": OPENRASTER_OPERATION_VERSION,
+        "output_dir": str(destination),
+        "manifest_path": str(destination / "manifest.json"),
+        "composite_path": str(destination / "composite.png"),
+        "evidence_path": str(destination / OPENRASTER_EVIDENCE),
+        "ora_sha256": ora_sha256,
+        "layer_count": len(bottom_to_top),
+        "verification": evidence["verification"],
+        "warnings": warnings,
+    }
 
 
 def export_psd(

--- a/src/vulca/layers/manifest.py
+++ b/src/vulca/layers/manifest.py
@@ -42,6 +42,7 @@ def write_manifest(
     partial: bool = False,
     warnings: list | None = None,
     layer_extras: dict[str, dict] | None = None,
+    layer_files: dict[str, str] | None = None,
     tradition: str = "",
 ) -> str:
     """Write manifest V3 JSON to output_dir/manifest.json. Returns path."""
@@ -49,6 +50,23 @@ def write_manifest(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     extras = layer_extras or {}
+    files = layer_files or {}
+    unknown_file_ids = set(files) - {info.id for info in layers}
+    if unknown_file_ids:
+        raise ValueError(f"layer_files contains unknown layer ids: {sorted(unknown_file_ids)}")
+    for layer_id, relative_path in files.items():
+        if not isinstance(relative_path, str) or not relative_path:
+            raise ValueError(f"layer_files[{layer_id!r}] must be a safe relative PNG path")
+        normalized = Path(relative_path)
+        if (
+            normalized.is_absolute()
+            or "\\" in relative_path
+            or "\x00" in relative_path
+            or ".." in normalized.parts
+            or (normalized.parts and ":" in normalized.parts[0])
+            or normalized.suffix.lower() != ".png"
+        ):
+            raise ValueError(f"layer_files[{layer_id!r}] must be a safe relative PNG path")
     for lid, extra_dict in extras.items():
         if not isinstance(extra_dict, dict):
             raise ValueError(
@@ -84,7 +102,7 @@ def write_manifest(
                 "content_type": info.content_type,
                 "visible": info.visible,
                 "locked": info.locked,
-                "file": f"{info.name}.png",
+                "file": files.get(info.id, f"{info.name}.png"),
                 "dominant_colors": info.dominant_colors,
                 "regeneration_prompt": info.regeneration_prompt,
                 "opacity": info.opacity,

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -9,7 +9,7 @@ successfully.
   2. Generation:   generate_image, create_artwork, generate_concepts, inpaint_artwork
   3. Evaluation:   evaluate_artwork, view_image
   4. Layer editing: layers_split, layers_list, layers_edit, layers_transform,
-                    layers_redraw, layers_composite, layers_export, layers_evaluate
+                    layers_redraw, layers_composite, layers_export, layers_import_openraster, layers_evaluate
   5. Session:      archive_session, sync_data, unload_models
 
 Typical agent loop: brief_parse → get_tradition_guide → generate_image → view_image
@@ -56,6 +56,7 @@ _TOOL_TIERS: dict[str, str] = {
     "layers_edit": "advanced", "layers_redraw": "advanced",
     "layers_evaluate": "advanced",
     "layers_export": "advanced",
+    "layers_import_openraster": "advanced",
     "layers_transform": "advanced",
     "generate_image": "core",
     "view_image": "core",
@@ -1459,15 +1460,15 @@ async def layers_export(
     export_format: str = "png",
     output_path: str = "",
 ) -> dict:
-    """Export the artwork as a PNG composite or PSD file — for delivery or external editing.
+    """Export artwork as PNG, a legacy PSD directory, or an OpenRaster archive.
 
     Use at the end of a workflow after layers_composite confirms the result looks correct.
-    PSD format preserves individual layers for editing in Photoshop or Affinity Photo.
+    ORA preserves flat full-canvas layers for editing in Krita and records round-trip hash evidence.
 
     Args:
         artwork_dir: Directory containing layer PNGs and manifest.json.
-        export_format: "png" (flat composite, default) or "psd" (layered Photoshop file).
-        output_path: Output path (default: <artwork_dir>/composite.png or layers.psd).
+        export_format: "png" (flat, default), "psd" (legacy PNG directory), or "ora" (OpenRaster).
+        output_path: Output path (default: composite.png, layers.psd, or layers.ora).
 
     Returns:
         export_path: Absolute path to the exported file.
@@ -1475,7 +1476,7 @@ async def layers_export(
     import json as json_mod
     from pathlib import Path
     from vulca.layers.edit import load_artwork
-    from vulca.layers.export import export_psd
+    from vulca.layers.export import export_openraster, export_psd
     from vulca.layers.composite import composite_layers
 
     artwork = load_artwork(artwork_dir)
@@ -1491,14 +1492,33 @@ async def layers_export(
         except Exception:
             pass
 
+    if export_format == "ora":
+        out = output_path or str(Path(artwork_dir) / "layers.ora")
+        return export_openraster(artwork_dir, out)
     if export_format == "psd":
         out = output_path or str(Path(artwork_dir) / "layers.psd")
         export_psd(artwork.layers, width=width, height=height, output_path=out)
-    else:
+    elif export_format == "png":
         out = output_path or str(Path(artwork_dir) / "composite.png")
         composite_layers(artwork.layers, width=width, height=height, output_path=out)
+    else:
+        return {"error": "export_format must be png, psd, or ora"}
 
     return {"export_path": out}
+
+
+@mcp.tool()
+async def layers_import_openraster(
+    archive_path: str,
+    output_dir: str,
+) -> dict:
+    """Import flat OpenRaster layers into a new VULCA artwork directory with hash evidence."""
+    from vulca.layers.export import import_openraster
+
+    try:
+        return import_openraster(archive_path, output_dir)
+    except Exception as exc:
+        return {"error": str(exc)}
 
 
 @mcp.tool()

--- a/tests/test_layers_v2_manifest.py
+++ b/tests/test_layers_v2_manifest.py
@@ -124,6 +124,29 @@ class TestWriteManifestV2:
         write_manifest([layer], output_dir=str(new_dir), width=512, height=512)
         assert (new_dir / "manifest.json").exists()
 
+    def test_accepts_safe_layer_file_override(self, tmp_path):
+        layer = _make_layer("subject", z_index=0, id="stable-subject")
+        path = write_manifest(
+            [layer],
+            output_dir=str(tmp_path),
+            width=512,
+            height=512,
+            layer_files={"stable-subject": "layers/0000_subject.png"},
+        )
+        data = json.loads(Path(path).read_text())
+        assert data["layers"][0]["file"] == "layers/0000_subject.png"
+
+    def test_rejects_unsafe_layer_file_override(self, tmp_path):
+        layer = _make_layer("subject", z_index=0, id="stable-subject")
+        with pytest.raises(ValueError, match="safe relative PNG path"):
+            write_manifest(
+                [layer],
+                output_dir=str(tmp_path),
+                width=512,
+                height=512,
+                layer_files={"stable-subject": "../escape.png"},
+            )
+
 
 class TestLoadManifestV2:
     def test_load_v2_manifest(self, tmp_path):

--- a/tests/test_openraster_roundtrip.py
+++ b/tests/test_openraster_roundtrip.py
@@ -1,0 +1,352 @@
+"""OpenRaster round-trip Effect Pack tests."""
+
+from __future__ import annotations
+
+import json
+import io
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+from PIL import Image, ImageDraw
+
+from vulca.layers.composite import composite_layers
+from vulca.layers.export import (
+    OPENRASTER_MIMETYPE,
+    OpenRasterError,
+    export_openraster,
+    import_openraster,
+)
+from vulca.layers.manifest import load_manifest, write_manifest
+from vulca.layers.types import LayerInfo, LayerResult
+
+
+def _rgba_bytes(path: str | Path) -> bytes:
+    with Image.open(path) as image:
+        return image.convert("RGBA").tobytes()
+
+
+def _make_artwork(root: Path) -> tuple[Path, list[LayerResult]]:
+    artwork = root / "source-artwork"
+    layers_dir = artwork / "layers"
+    layers_dir.mkdir(parents=True)
+    width, height = 48, 32
+
+    background = Image.new("RGBA", (width, height), (238, 224, 196, 255))
+    subject = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    ImageDraw.Draw(subject).ellipse((11, 5, 35, 29), fill=(65, 105, 160, 230))
+    light = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    ImageDraw.Draw(light).rectangle((2, 2, 18, 10), fill=(255, 210, 80, 180))
+
+    infos = [
+        LayerInfo(
+            id="layer_background",
+            name="paper_base",
+            description="Warm paper",
+            z_index=10,
+            content_type="background",
+            visible=True,
+            blend_mode="normal",
+            opacity=1.0,
+            tradition_role="底纸",
+        ),
+        LayerInfo(
+            id="layer_subject",
+            name="blue_subject",
+            description="Main blue form",
+            z_index=20,
+            content_type="subject",
+            visible=True,
+            blend_mode="multiply",
+            opacity=0.65,
+            semantic_path="subject.main",
+            regeneration_prompt="Keep the silhouette.\nPreserve the blue value group.",
+        ),
+        LayerInfo(
+            id="layer_light",
+            name="hidden_light",
+            description="Optional light",
+            z_index=30,
+            content_type="effect",
+            visible=False,
+            blend_mode="screen",
+            opacity=0.4,
+        ),
+    ]
+    images = [background, subject, light]
+    file_map: dict[str, str] = {}
+    results: list[LayerResult] = []
+    for position, (info, image) in enumerate(zip(infos, images, strict=True)):
+        relative = f"layers/{position:02d}.png"
+        path = artwork / relative
+        image.save(path)
+        file_map[info.id] = relative
+        results.append(LayerResult(info=info, image_path=str(path), scores={"L1": 0.8 - position * 0.1}))
+
+    write_manifest(
+        infos,
+        output_dir=str(artwork),
+        width=width,
+        height=height,
+        split_mode="test-fixture",
+        tradition="test-tradition",
+        layer_files=file_map,
+    )
+    composite_layers(results, width=width, height=height, output_path=str(artwork / "composite.png"))
+    return artwork, results
+
+
+def _rewrite_archive(
+    source: Path,
+    destination: Path,
+    replacements: dict[str, bytes],
+    *,
+    omit: set[str] | None = None,
+    renames: dict[str, str] | None = None,
+) -> None:
+    omitted = omit or set()
+    renamed = renames or {}
+    with zipfile.ZipFile(source, "r") as original, zipfile.ZipFile(destination, "w", allowZip64=True) as rewritten:
+        for original_info in original.infolist():
+            if original_info.filename in omitted:
+                continue
+            payload = replacements.get(original_info.filename, original.read(original_info))
+            info = zipfile.ZipInfo(renamed.get(original_info.filename, original_info.filename), date_time=original_info.date_time)
+            info.compress_type = original_info.compress_type
+            info.external_attr = original_info.external_attr
+            rewritten.writestr(info, payload)
+
+
+def test_openraster_no_edit_roundtrip_preserves_pixels_and_core_metadata(tmp_path: Path) -> None:
+    artwork, original_layers = _make_artwork(tmp_path)
+    archive = tmp_path / "layers.ora"
+    exported = export_openraster(str(artwork), str(archive))
+
+    assert Path(exported["export_path"]) == archive
+    assert len(exported["ora_sha256"]) == 64
+    assert exported["provider"] == "not_applicable"
+    with zipfile.ZipFile(archive, "r") as opened:
+        infos = opened.infolist()
+        assert infos[0].filename == "mimetype"
+        assert infos[0].compress_type == zipfile.ZIP_STORED
+        assert opened.read("mimetype") == OPENRASTER_MIMETYPE
+        assert {"stack.xml", "mergedimage.png", "Thumbnails/thumbnail.png", "vulca.json"}.issubset(opened.namelist())
+        stack = ET.fromstring(opened.read("stack.xml"))
+        root_stack = next(child for child in stack if child.tag == "stack")
+        assert [layer.get("name").split(" [vulca-id:", 1)[0] for layer in root_stack] == [
+            "hidden_light",
+            "blue_subject",
+            "paper_base",
+        ]
+
+    imported_dir = tmp_path / "imported"
+    imported = import_openraster(str(archive), str(imported_dir))
+    assert imported["verification"]["no_edit_roundtrip"] is True
+    loaded = load_manifest(str(imported_dir))
+    assert [layer.info.id for layer in loaded.layers] == [layer.info.id for layer in original_layers]
+    assert [layer.info.name for layer in loaded.layers] == [layer.info.name for layer in original_layers]
+    assert [layer.info.z_index for layer in loaded.layers] == [10, 20, 30]
+    assert [layer.info.visible for layer in loaded.layers] == [True, True, False]
+    assert [layer.info.blend_mode for layer in loaded.layers] == ["normal", "multiply", "screen"]
+    assert [layer.info.opacity for layer in loaded.layers] == [1.0, 0.65, 0.4]
+    assert loaded.layers[1].info.regeneration_prompt == "Keep the silhouette.\nPreserve the blue value group."
+    for before, after in zip(original_layers, loaded.layers, strict=True):
+        assert _rgba_bytes(before.image_path) == _rgba_bytes(after.image_path)
+    assert _rgba_bytes(artwork / "composite.png") == _rgba_bytes(imported_dir / "composite.png")
+
+    evidence = json.loads((imported_dir / "openraster-roundtrip.json").read_text(encoding="utf-8"))
+    assert evidence["verification"]["status"] == "verified-no-edit"
+    assert all(layer["pixels_changed"] is False for layer in evidence["layers"])
+    assert evidence["provider"] == "not_applicable"
+
+
+def test_openraster_roundtrips_repository_layered_demo_asset(tmp_path: Path) -> None:
+    source = Path(__file__).resolve().parent.parent / "assets" / "demo" / "v2" / "layers-split"
+    archive = tmp_path / "repository-demo.ora"
+    result = export_openraster(str(source), str(archive))
+    assert result["layer_count"] == 6
+
+    imported_dir = tmp_path / "repository-demo-import"
+    imported = import_openraster(str(archive), str(imported_dir))
+    assert imported["verification"]["no_edit_roundtrip"] is True
+    before = load_manifest(str(source))
+    after = load_manifest(str(imported_dir))
+    assert [layer.info.id for layer in after.layers] == [layer.info.id for layer in before.layers]
+    assert [layer.info.name for layer in after.layers] == [layer.info.name for layer in before.layers]
+    for source_layer, imported_layer in zip(before.layers, after.layers, strict=True):
+        assert _rgba_bytes(source_layer.image_path) == _rgba_bytes(imported_layer.image_path)
+
+
+def test_openraster_import_records_only_the_edited_layer(tmp_path: Path) -> None:
+    artwork, _ = _make_artwork(tmp_path)
+    archive = tmp_path / "layers.ora"
+    export_openraster(str(artwork), str(archive))
+    with zipfile.ZipFile(archive, "r") as opened:
+        sidecar = json.loads(opened.read("vulca.json"))
+        target = next(layer for layer in sidecar["layers"] if layer["id"] == "layer_subject")
+        with Image.open(Path(artwork) / "layers" / "01.png") as source_image:
+            edited = source_image.convert("RGBA")
+        edited.putpixel((12, 6), (250, 20, 30, 255))
+        output = io.BytesIO()
+        edited.save(output, format="PNG")
+
+    edited_archive = tmp_path / "edited.ora"
+    _rewrite_archive(archive, edited_archive, {target["src"]: output.getvalue()})
+    imported_dir = tmp_path / "edited-import"
+    imported = import_openraster(str(edited_archive), str(imported_dir))
+    assert imported["verification"]["no_edit_roundtrip"] is False
+    evidence = json.loads((imported_dir / "openraster-roundtrip.json").read_text(encoding="utf-8"))
+    changed = {item["id"]: item["pixels_changed"] for item in evidence["layers"]}
+    assert changed == {"layer_background": False, "layer_subject": True, "layer_light": False}
+
+
+def test_openraster_import_uses_layer_markers_when_sidecar_is_removed(tmp_path: Path) -> None:
+    artwork, original_layers = _make_artwork(tmp_path)
+    archive = tmp_path / "layers.ora"
+    export_openraster(str(artwork), str(archive))
+    stripped = tmp_path / "without-sidecar.ora"
+    _rewrite_archive(archive, stripped, {}, omit={"vulca.json"})
+
+    imported_dir = tmp_path / "fallback-import"
+    result = import_openraster(str(stripped), str(imported_dir))
+    assert result["verification"]["no_edit_roundtrip"] is False
+    assert result["warnings"]
+    loaded = load_manifest(str(imported_dir))
+    assert [layer.info.id for layer in loaded.layers] == [layer.info.id for layer in original_layers]
+
+
+def test_openraster_reorder_updates_canonical_order_without_losing_ids(tmp_path: Path) -> None:
+    artwork, original_layers = _make_artwork(tmp_path)
+    archive = tmp_path / "layers.ora"
+    export_openraster(str(artwork), str(archive))
+    with zipfile.ZipFile(archive, "r") as opened:
+        stack = ET.fromstring(opened.read("stack.xml"))
+        root_stack = next(child for child in stack if child.tag == "stack")
+        children = list(root_stack)
+        root_stack[:] = list(reversed(children))
+        changed_stack = ET.tostring(stack, encoding="utf-8", xml_declaration=True)
+
+    reordered = tmp_path / "reordered.ora"
+    _rewrite_archive(archive, reordered, {"stack.xml": changed_stack})
+    imported_dir = tmp_path / "reordered-import"
+    result = import_openraster(str(reordered), str(imported_dir))
+    assert result["verification"]["layer_order_changed"] is True
+    loaded = load_manifest(str(imported_dir))
+    assert [layer.info.id for layer in loaded.layers] == list(
+        reversed([layer.info.id for layer in original_layers])
+    )
+    assert [layer.info.z_index for layer in loaded.layers] == [10, 20, 30]
+
+
+def test_openraster_matches_sidecar_metadata_by_id_after_internal_path_change(tmp_path: Path) -> None:
+    artwork, _ = _make_artwork(tmp_path)
+    archive = tmp_path / "layers.ora"
+    export_openraster(str(artwork), str(archive))
+    with zipfile.ZipFile(archive, "r") as opened:
+        sidecar = json.loads(opened.read("vulca.json"))
+        subject = next(layer for layer in sidecar["layers"] if layer["id"] == "layer_subject")
+        old_src = subject["src"]
+        new_src = "data/editor-renamed-subject.png"
+        stack = ET.fromstring(opened.read("stack.xml"))
+        root_stack = next(child for child in stack if child.tag == "stack")
+        target = next(child for child in root_stack if child.get("src") == old_src)
+        target.set("src", new_src)
+        changed_stack = ET.tostring(stack, encoding="utf-8", xml_declaration=True)
+
+    renamed_archive = tmp_path / "renamed-path.ora"
+    _rewrite_archive(
+        archive,
+        renamed_archive,
+        {"stack.xml": changed_stack},
+        renames={old_src: new_src},
+    )
+    imported_dir = tmp_path / "renamed-path-import"
+    result = import_openraster(str(renamed_archive), str(imported_dir))
+    assert any("metadata matched by stable id" in warning for warning in result["warnings"])
+    loaded = load_manifest(str(imported_dir))
+    subject_layer = next(layer for layer in loaded.layers if layer.info.id == "layer_subject")
+    assert subject_layer.info.regeneration_prompt == "Keep the silhouette.\nPreserve the blue value group."
+
+
+def test_openraster_rejects_zip_slip_without_creating_destination(tmp_path: Path) -> None:
+    archive = tmp_path / "malicious.ora"
+    with zipfile.ZipFile(archive, "w") as opened:
+        mimetype = zipfile.ZipInfo("mimetype")
+        mimetype.compress_type = zipfile.ZIP_STORED
+        opened.writestr(mimetype, OPENRASTER_MIMETYPE)
+        opened.writestr("../escape.png", b"not-an-image")
+    destination = tmp_path / "must-not-exist"
+    with pytest.raises(OpenRasterError, match="Unsafe OpenRaster archive path"):
+        import_openraster(str(archive), str(destination))
+    assert not destination.exists()
+    assert not (tmp_path.parent / "escape.png").exists()
+
+
+def test_openraster_import_never_overwrites_existing_destination(tmp_path: Path) -> None:
+    artwork, _ = _make_artwork(tmp_path)
+    archive = tmp_path / "layers.ora"
+    export_openraster(str(artwork), str(archive))
+    destination = tmp_path / "existing"
+    destination.mkdir()
+    sentinel = destination / "keep.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    with pytest.raises(OpenRasterError, match="already exists"):
+        import_openraster(str(archive), str(destination))
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+
+
+def test_openraster_export_rejects_layer_file_outside_artwork(tmp_path: Path) -> None:
+    artwork, _ = _make_artwork(tmp_path)
+    outside = tmp_path / "outside.png"
+    Image.new("RGBA", (48, 32), (255, 0, 0, 255)).save(outside)
+    manifest_path = artwork / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["layers"][0]["file"] = "../outside.png"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(OpenRasterError, match="inside the artwork directory"):
+        export_openraster(str(artwork), str(tmp_path / "must-not-exist.ora"))
+    assert not (tmp_path / "must-not-exist.ora").exists()
+
+
+def test_openraster_rejects_excessive_decoded_layer_workload(tmp_path: Path) -> None:
+    archive = tmp_path / "oversized-workload.ora"
+    stack = b'''<?xml version="1.0" encoding="UTF-8"?>
+<image version="0.0.6" w="10000" h="10000"><stack>
+<layer name="a [vulca-id:YQ]" src="data/a.png"/>
+<layer name="b [vulca-id:Yg]" src="data/b.png"/>
+<layer name="c [vulca-id:Yw]" src="data/c.png"/>
+</stack></image>'''
+    with zipfile.ZipFile(archive, "w") as opened:
+        mimetype = zipfile.ZipInfo("mimetype")
+        mimetype.compress_type = zipfile.ZIP_STORED
+        opened.writestr(mimetype, OPENRASTER_MIMETYPE)
+        opened.writestr("stack.xml", stack)
+
+    with pytest.raises(OpenRasterError, match="decoded-pixel safety limit"):
+        import_openraster(str(archive), str(tmp_path / "must-not-exist"))
+
+
+def test_cli_lists_openraster_export_and_import(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    export_help = subprocess.run(
+        [sys.executable, "-m", "vulca", "layers", "export", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert export_help.returncode == 0, export_help.stderr
+    assert "{png,psd,ora}" in export_help.stdout
+    import_help = subprocess.run(
+        [sys.executable, "-m", "vulca", "layers", "import-ora", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert import_help.returncode == 0, import_help.stderr
+    assert "output_dir" in import_help.stdout


### PR DESCRIPTION
## Summary

Adds one SDK-native, non-generative engineering Effect Pack: `openraster-roundtrip`. It reuses the existing Artifact/manifest, `LayerInfo`, CLI/MCP, compositing, and evidence boundaries; it does not import Layered Redraw's parallel project/editor/preset contracts.

Public surfaces:

- `export_openraster(artwork_dir, output_path)`
- `import_openraster(input_path, output_dir)`
- `vulca layers export ... --format ora`
- `vulca layers import-ora ...`
- `layers_export(export_format="ora")`
- `layers_import_openraster`

A no-edit round trip protects canvas, layer count and stable IDs, order, names, visibility, opacity, supported blends, decoded RGBA pixels, and the recomposited RGBA result. Import writes `openraster-roundtrip.json` with archive/document/layer/composite hashes. Provider/model/prompt/seed/cost/latency are explicitly `not_applicable`.

## Type of change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking)
- [ ] Breaking change (behaviour / API / CLI compat)
- [x] Documentation / skill body / BP
- [ ] Dependency / tooling

## Checklist

- [x] Tests added or updated (ran `pytest` locally)
- [x] `CHANGELOG.md` updated under next unreleased section
- [x] Agent-native discipline checked — fixed thresholds are archive/resource safety limits, not creative decisions; unsupported capabilities fail explicitly
- [ ] Follows commit style (the final changelog commit is conventional; the first two focused implementation commits use descriptive non-conventional subjects)
- [x] No binary artefacts committed

## Safety and deliberate limits

- new destination only; sibling staging plus atomic promotion
- ZIP path, duplicate-entry, encryption/compression, member-size, decoded-workload, XML DTD/entity, and canvas limits
- source layer files must remain inside the source artwork
- flat, full-canvas layers only; unsupported transforms/blends fail explicitly
- layer additions/deletions rejected while the VULCA sidecar is present
- advanced/experimental; no artistic-quality claim

## Verification

- 71 related Artifact/manifest/alpha/CLI/OpenRaster tests passed
- 11 dedicated OpenRaster tests passed, including the existing six-layer repository demo asset and hostile/failure cases; the safe manifest-file mapping is covered by the manifest contract suite
- clean-clone OpenRaster suite: 11 passed, with imports verified from the clean clone
- `ruff check src tests`, Python compilation, and `git diff --check` passed
- local seed baseline gate passed
- tiny training/eval gate passed

A full Windows run was also attempted with the repository CI ignore list. It reached 194 passed / 10 skipped before an existing locale-dependent test read `cli.py` with GBK and failed on pre-existing UTF-8 text; this patch's new CLI strings are ASCII. Heavy torch-only tests remain covered by the repository's existing CI ignore policy.

## Dogfooding note

The repository-owned six-layer `assets/demo/v2/layers-split` artwork was exported to ORA, re-imported, and verified for stable IDs, names, every decoded RGBA layer, and the composite. Failure tests cover edited pixels, reorder, sidecar loss, internal path rename, ZIP slip, source traversal, excessive decoded workload, and destination overwrite refusal.

## Explicit non-claims

- not released or plugin-integrated
- no provider/model execution
- no artistic improvement or human acceptance
- no preservation claim for Artifact-only fields outside the current manifest writer
