### PR TITLE
docs: add Professional services section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,20 @@ From an agent: `/evaluate` calls the `evaluate_artwork` MCP tool and returns evo
 
 ---
 
+## Professional services
+
+The SDK is Apache 2.0 and free to use. [Issues](https://github.com/vulca-org/vulca-visual-control-sdk/issues) are the right place for bugs, feature requests, and workflow needs — those cost nothing and always will.
+
+If you would rather have the author do the work, three scoped engagements are bookable:
+
+| Engagement | What you get | From |
+|---|---|---|
+| [Pre-release audit](https://contra.com/s/bYreA76Y-llm-vlm-evaluation-harness-benchmark-llm-as-judge) | Your AI-generated visuals or LLM outputs scored against a rubric your team signs off on — a pass / repair / withhold decision per asset, each with a reason | $600 · 1 week |
+| [Custom MCP server or Claude Code plugin](https://contra.com/s/cvLZq3U6-custom-mcp-server-or-claude-code-plugin-for-your-workflow) | Your API, dataset, or workflow turned into tools an agent can call reliably — tool schemas, guardrails, tests, setup docs | $1,000 · 2 weeks |
+| [Bounded creative job](https://contra.com/s/2LYcLrbY-bounded-creative-job-one-brief-in-a-released-package-out) | One approved brief in; a checked, human-released package out, with a manifest and a delivery receipt explaining why each asset shipped | $2,500 · 2 weeks |
+
+Maintained by [Haorui Yu](https://contra.com/_qt7lsowm) — PhD researcher in vision-language model evaluation at the University of Dundee, and first author of the papers above.
+
 ## Support
 
 - **Issues:** [github.com/vulca-org/vulca-visual-control-sdk/issues](https://github.com/vulca-org/vulca-visual-control-sdk/issues) — bug reports, feature requests, workflow needs that should become a skill


### PR DESCRIPTION
Adds a `## Professional services` section to the README, placed after **Showcase** and before **Support**.

**Scope: documentation only.** No code, config, workflow, or dependency changes — the diff is 14 added lines in `README.md` and nothing else.

### What it says

Three scoped engagements, listed in ascending price order, each linking to its booking page:

| Engagement | From |
|---|---|
| Pre-release audit | $600 · 1 week |
| Custom MCP server or Claude Code plugin | $1,000 · 2 weeks |
| Bounded creative job | $2,500 · 2 weeks |

The first sentence states that the SDK stays Apache 2.0 and that issues remain free, so the section does not read as an open-core upsell. The section makes no claim about customers, case studies, or testimonials, because there are none yet.

### Link verification (2026-09-03)

All five links return HTTP 200 with matching page titles. A deliberately bogus service id returns 404, which confirms the 200s are real pages rather than an SPA catch-all route.

### Not in scope

`README.md:271` describes VULCA-Bench as "7,410 samples, 9 traditions", which conflicts with the project's own convention of citing **eight** traditions for the public arXiv reference. That predates this branch and is left untouched here; it needs a separate decision on which figure is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)