### PR TITLE
fix: mock and crashed evaluations must not look like verdicts

### DIFF
--- a/src/vulca/_engine.py
+++ b/src/vulca/_engine.py
@@ -236,6 +236,10 @@ class Engine:
         # A mock run calls no API, so it has no cost to report.
         cost = 0.0 if self.mock else _estimate_cost(skills or [])
 
+        # score_image swallows every exception and returns zeros; carry that
+        # fact onto the result so callers are not handed a fabricated verdict.
+        scoring_error = str(vlm_result.get("error") or "")
+
         return EvalResult(
             score=round(weighted_total, 4),
             tradition=resolved_tradition,
@@ -258,6 +262,8 @@ class Engine:
             intent_confidence=intent_confidence,
             cost_usd=cost,
             mock=self.mock,
+            failed=bool(scoring_error),
+            error=scoring_error,
             raw=vlm_result,
         )
 

--- a/src/vulca/_engine.py
+++ b/src/vulca/_engine.py
@@ -233,7 +233,8 @@ class Engine:
 
         summary = _build_summary(weighted_total, resolved_tradition, dimensions, mode)
 
-        cost = _estimate_cost(skills or [])
+        # A mock run calls no API, so it has no cost to report.
+        cost = 0.0 if self.mock else _estimate_cost(skills or [])
 
         return EvalResult(
             score=round(weighted_total, 4),
@@ -256,6 +257,7 @@ class Engine:
             skills=skill_results,
             intent_confidence=intent_confidence,
             cost_usd=cost,
+            mock=self.mock,
             raw=vlm_result,
         )
 

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -626,20 +626,41 @@ def _cmd_evaluate(args: argparse.Namespace) -> None:
     if args.json:
         import dataclasses
         print(json_mod.dumps(dataclasses.asdict(result), indent=2, ensure_ascii=False))
-        return
+        sys.exit(_exit_code_for(result))
 
     if mode == "reference":
         _print_reference_result(result)
     else:
         _print_strict_result(result)
 
+    sys.exit(_exit_code_for(result))
+
 
 
 _MOCK_BANNER = (
-    "  !! MOCK EVALUATION -- scores below are synthetic. "
-    "No model was called,\n"
-    "     and nothing here is evidence about this image."
+    "  !! MOCK RUN -- no model was called. Everything below is synthetic\n"
+    "     and is not evidence about anything real."
 )
+
+
+_FAILED_BANNER = (
+    "  !! SCORING FAILED -- the dimensions below are not measurements.\n"
+    "     Every level reads 0% because scoring raised, not because the work\n"
+    "     scored zero. Do not record this as a verdict."
+)
+
+
+def _print_failure_banner(result) -> None:
+    """Say that a run crashed, where a reader cannot mistake it for a verdict."""
+    if getattr(result, "failed", False):
+        print(f"\n{_FAILED_BANNER}")
+        if getattr(result, "error", ""):
+            print(f"     Error: {result.error}")
+
+
+def _exit_code_for(result) -> int:
+    """A crashed evaluation must not leave the shell believing it succeeded."""
+    return 1 if getattr(result, "failed", False) else 0
 
 
 def _print_mock_banner(result) -> None:
@@ -658,6 +679,7 @@ def _print_cost_line(result) -> None:
 
 def _print_strict_result(result) -> None:
     """Strict mode output: judge style with pass/fail indicators."""
+    _print_failure_banner(result)
     _print_mock_banner(result)
     print(f"\n  VULCA Evaluation Result")
     print(f"  {'=' * 50}")
@@ -708,6 +730,7 @@ def _print_strict_result(result) -> None:
 
 def _print_reference_result(result) -> None:
     """Reference mode output: advisor style with deviation analysis."""
+    _print_failure_banner(result)
     _print_mock_banner(result)
     print(f"\n  VULCA Cultural Analysis (reference mode)")
     print(f"  {'=' * 50}")
@@ -792,6 +815,8 @@ def _cmd_evaluate_fusion(args: argparse.Namespace, skills: list[str] | None) -> 
 
 def _print_fusion_result(results) -> None:
     """Comparison table across traditions. Extracted so it can be tested."""
+    for _, r in results:
+        _print_failure_banner(r)
     if any(getattr(r, "mock", False) for _, r in results):
         print(f"\n{_MOCK_BANNER}")
     print(f"\n  VULCA Fusion Analysis ({len(results)} traditions)")
@@ -968,6 +993,14 @@ def _cmd_create(args: argparse.Namespace) -> None:
         print(json_mod.dumps(data, indent=2, ensure_ascii=False))
         return
 
+    _print_create_result(result, image_path)
+
+
+def _print_create_result(result, image_path: str = "") -> None:
+    """Creation summary. Extracted so its disclosure can be tested."""
+    _print_mock_banner(result)
+    if result.provider:
+        print(f"\n  Provider:  {result.provider}")
     print(f"\n  VULCA Creation Result")
     print(f"  {'=' * 40}")
     print(f"  Session:   {result.session_id}")

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -635,8 +635,30 @@ def _cmd_evaluate(args: argparse.Namespace) -> None:
 
 
 
+_MOCK_BANNER = (
+    "  !! MOCK EVALUATION -- scores below are synthetic. "
+    "No model was called,\n"
+    "     and nothing here is evidence about this image."
+)
+
+
+def _print_mock_banner(result) -> None:
+    """Announce a synthetic score sheet, at the top where it cannot be missed."""
+    if getattr(result, "mock", False):
+        print(f"\n{_MOCK_BANNER}")
+
+
+def _print_cost_line(result) -> None:
+    """Cost and latency, or a plain statement that a mock run has neither."""
+    if getattr(result, "mock", False):
+        print("\n  MOCK run: no API call, no cost.")
+    else:
+        print(f"\n  Latency: {result.latency_ms}ms | Cost: ${result.cost_usd:.4f}")
+
+
 def _print_strict_result(result) -> None:
     """Strict mode output: judge style with pass/fail indicators."""
+    _print_mock_banner(result)
     print(f"\n  VULCA Evaluation Result")
     print(f"  {'=' * 50}")
     print(f"  Score:     {result.score:.0%}")
@@ -680,12 +702,13 @@ def _print_strict_result(result) -> None:
         for name, sr in result.skills.items():
             print(f"    {name}: {sr.score:.0%} -- {sr.summary}")
 
-    print(f"\n  Latency: {result.latency_ms}ms | Cost: ${result.cost_usd:.4f}")
+    _print_cost_line(result)
     print()
 
 
 def _print_reference_result(result) -> None:
     """Reference mode output: advisor style with deviation analysis."""
+    _print_mock_banner(result)
     print(f"\n  VULCA Cultural Analysis (reference mode)")
     print(f"  {'=' * 50}")
     print(f"  Alignment: {result.score:.0%}")
@@ -726,7 +749,7 @@ def _print_reference_result(result) -> None:
 
     print()
     print(f"  Summary: {result.summary}")
-    print(f"\n  Latency: {result.latency_ms}ms | Cost: ${result.cost_usd:.4f}")
+    _print_cost_line(result)
     print()
 
 
@@ -764,6 +787,13 @@ def _cmd_evaluate_fusion(args: argparse.Namespace, skills: list[str] | None) -> 
         print(json_mod.dumps(all_data, indent=2, ensure_ascii=False))
         return
 
+    _print_fusion_result(results)
+
+
+def _print_fusion_result(results) -> None:
+    """Comparison table across traditions. Extracted so it can be tested."""
+    if any(getattr(r, "mock", False) for _, r in results):
+        print(f"\n{_MOCK_BANNER}")
     print(f"\n  VULCA Fusion Analysis ({len(results)} traditions)")
     print(f"  {'=' * 60}")
     print()
@@ -804,15 +834,19 @@ def _cmd_evaluate_fusion(args: argparse.Namespace, skills: list[str] | None) -> 
             dims = ", ".join(f"{d} ({_DIM_NAMES[d]})" for d in departures)
             print(f"    vs {tradition}: departures in {dims}")
 
-    total_cost = sum(r.cost_usd for _, r in results)
-    total_latency = sum(r.latency_ms for _, r in results)
-    print(f"\n  Latency: {total_latency}ms | Cost: ${total_cost:.4f}")
+    if any(getattr(r, "mock", False) for _, r in results):
+        print("\n  MOCK run: no API call, no cost.")
+    else:
+        total_cost = sum(r.cost_usd for _, r in results)
+        total_latency = sum(r.latency_ms for _, r in results)
+        print(f"\n  Latency: {total_latency}ms | Cost: ${total_cost:.4f}")
     print()
 
 
 # ---------------------------------------------------------------------------
 # Create command
 # ---------------------------------------------------------------------------
+
 
 def _cmd_create(args: argparse.Namespace) -> None:
     import json as json_mod
@@ -959,7 +993,7 @@ def _cmd_create(args: argparse.Namespace) -> None:
         for r in result.recommendations:
             print(f"    - {r}")
 
-    print(f"\n  Latency: {result.latency_ms}ms | Cost: ${result.cost_usd:.4f}")
+    _print_cost_line(result)
     print()
 
 

--- a/src/vulca/create.py
+++ b/src/vulca/create.py
@@ -183,6 +183,8 @@ async def _create_local(
         eval_mode=eval_mode,
         latency_ms=output.total_latency_ms,
         cost_usd=output.total_cost_usd,
+        provider=output.original_provider or provider,
+        mock=(output.original_provider or provider) == "mock",
         raw=output.to_dict(),
     )
 
@@ -237,6 +239,8 @@ async def _create_remote(
         recommendations=data.get("recommendations") or [],
         latency_ms=data.get("latency_ms", 0),
         cost_usd=data.get("cost_usd", 0.0),
+        provider=data.get("provider", ""),
+        mock=data.get("provider", "") == "mock",
         raw=data,
     )
 

--- a/src/vulca/types.py
+++ b/src/vulca/types.py
@@ -83,6 +83,17 @@ class EvalResult:
     cost_usd: float = 0.0
     """Estimated API cost in USD."""
 
+    failed: bool = False
+    """True when scoring raised and the dimensions below are not measurements.
+
+    ``_vlm.score_image`` catches every exception and returns a complete payload
+    with all five dimensions at 0.0. Without this flag that crash is delivered
+    as a confident verdict of zero, which is worse than no answer at all.
+    """
+
+    error: str = ""
+    """The scoring error, when :attr:`failed` is set."""
+
     mock: bool = False
     """True when the scores are synthetic and no model was called.
 
@@ -185,6 +196,16 @@ class CreateResult:
     cost_usd: float = 0.0
     """Estimated API cost in USD."""
 
+    provider: str = ""
+    """Image provider that produced the artefact, as resolved at run time."""
+
+    mock: bool = False
+    """True when the artefact is synthetic and no generation API was called.
+
+    ``create`` picks a provider by name and ``mock`` is one of the choices, so a
+    run can be entirely synthetic without any flag being passed. The result
+    carries that fact rather than leaving it to the caller to infer.
+    """
 
     raw: dict = field(default_factory=dict)
     """Raw response data."""

--- a/src/vulca/types.py
+++ b/src/vulca/types.py
@@ -83,6 +83,14 @@ class EvalResult:
     cost_usd: float = 0.0
     """Estimated API cost in USD."""
 
+    mock: bool = False
+    """True when the scores are synthetic and no model was called.
+
+    Carried on the result so that every renderer and every downstream report can
+    say so. A mock score sheet is shaped exactly like a real one; without this
+    flag nothing downstream can tell them apart.
+    """
+
     raw: dict = field(default_factory=dict)
     """Raw response data for advanced usage."""
 

--- a/tests/test_mock_disclosure.py
+++ b/tests/test_mock_disclosure.py
@@ -114,3 +114,130 @@ class TestFusionDisclosesMock:
         out = buf.getvalue()
         assert MARKER not in out
         assert "Cost: $" in out
+
+
+# -- Create path -----------------------------------------------------------
+#
+# `create` selects a provider by name rather than a boolean, and "mock" is one
+# of the choices. A synthetic image with a printed price is the same failure as
+# a synthetic score sheet with one.
+
+
+def _bare_create(**over):
+    from vulca.types import CreateResult
+
+    base = dict(session_id="s1", mode="create", tradition="chinese_xieyi")
+    base.update(over)
+    return CreateResult(**base)
+
+
+class TestCreateCarriesProvenance:
+    def test_createresult_has_mock_and_provider_fields(self):
+        from vulca.types import CreateResult
+
+        assert "mock" in CreateResult.__dataclass_fields__
+        assert "provider" in CreateResult.__dataclass_fields__
+        r = _bare_create()
+        assert r.mock is False
+        assert r.provider == ""
+
+
+class TestCreateRendererDisclosesMock:
+    def _render(self, result) -> str:
+        import io
+        from contextlib import redirect_stdout
+        from vulca.cli import _print_create_result
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_create_result(result)
+        return buf.getvalue()
+
+    def test_mock_provider_is_disclosed(self):
+        out = self._render(_bare_create(mock=True, provider="mock", cost_usd=0.0))
+        assert MARKER in out
+        assert "Cost: $" not in out
+
+    def test_real_provider_is_not_marked(self):
+        out = self._render(_bare_create(provider="nb2", cost_usd=0.0042))
+        assert MARKER not in out
+        assert "Cost: $" in out
+
+
+# -- Failed scoring --------------------------------------------------------
+#
+# `_vlm.score_image` catches every exception and returns a complete result with
+# all five dimensions at 0.0. Nothing on that result says the run failed, so a
+# crash is delivered as a confident verdict of zero -- worse than a mock score,
+# because it happens without anyone asking for it.
+
+
+def _failed_vlm_payload(msg: str = "boom") -> dict:
+    """The shape `_vlm.score_image` returns from its except branch."""
+    out: dict = {"error": msg, "_extra_keys": []}
+    for level in ("L1", "L2", "L3", "L4", "L5"):
+        out[level] = 0.0
+        out[f"{level}_rationale"] = f"Scoring failed: {msg}" if level == "L1" else ""
+        out[f"{level}_suggestion"] = ""
+        out[f"{level}_deviation_type"] = "traditional"
+        out[f"{level}_observations"] = ""
+        out[f"{level}_reference_technique"] = ""
+    return out
+
+
+class TestFailedRunIsMarked:
+    def test_evalresult_has_failed_and_error_fields(self):
+        assert "failed" in EvalResult.__dataclass_fields__
+        assert "error" in EvalResult.__dataclass_fields__
+        r = _bare_result()
+        assert r.failed is False
+        assert r.error == ""
+
+    def test_engine_marks_a_failed_scoring_run(self, monkeypatch):
+        import vulca._engine as eng
+
+        async def _boom(**kwargs):
+            return _failed_vlm_payload("'NoneType' object has no attribute 'strip'")
+
+        monkeypatch.setattr(eng, "score_image", _boom)
+        monkeypatch.setattr(eng, "load_image_base64", lambda *a, **k: _immediate(("", "image/png")))
+
+        engine = eng.Engine(api_key="k")
+        result = asyncio.run(engine.run("x.png", tradition="chinese_xieyi"))
+        assert result.failed is True
+        assert "NoneType" in result.error
+        assert result.score == 0.0
+
+
+def _immediate(value):
+    async def _coro():
+        return value
+    return _coro()
+
+
+class TestRenderersDiscloseFailure:
+    def _render(self, result) -> str:
+        import io
+        from contextlib import redirect_stdout
+        from vulca.cli import _print_strict_result
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_strict_result(result)
+        return buf.getvalue()
+
+    def test_failed_output_is_marked(self):
+        out = self._render(_bare_result(score=0.0, failed=True, error="boom"))
+        assert "FAILED" in out
+        assert "boom" in out
+
+    def test_successful_output_is_not_marked(self):
+        assert "FAILED" not in self._render(_bare_result())
+
+
+class TestExitCode:
+    def test_failed_evaluation_exits_nonzero(self):
+        from vulca.cli import _exit_code_for
+
+        assert _exit_code_for(_bare_result(failed=True, error="boom")) != 0
+        assert _exit_code_for(_bare_result()) == 0

--- a/tests/test_mock_disclosure.py
+++ b/tests/test_mock_disclosure.py
@@ -1,0 +1,116 @@
+"""Mock evaluations must announce themselves.
+
+A mock run produces a full-looking score sheet. If nothing on that sheet says the
+scores are synthetic, a report built from it is indistinguishable from a report
+built from real model calls, and a misconfigured key or a stray --mock flag turns
+into a plausible-looking fabrication. These tests fix the disclosure contract:
+the flag travels with the result, and every renderer shows it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from vulca.types import EvalResult
+
+
+MARKER = "MOCK"
+
+
+def _mock_eval() -> EvalResult:
+    """A mock evaluation through the public API, as a user would obtain one."""
+    from vulca.evaluate import evaluate
+
+    return evaluate("nonexistent.png", tradition="chinese_xieyi", mock=True)
+
+
+def _bare_result(**over) -> EvalResult:
+    """A minimally-populated real result, for the negative case."""
+    base = dict(
+        score=0.82,
+        tradition="chinese_xieyi",
+        dimensions={f"L{i}": 0.8 for i in range(1, 6)},
+        rationales={f"L{i}": "" for i in range(1, 6)},
+        summary="Overall excellent.",
+        risk_level="low",
+        risk_flags=[],
+        recommendations=[],
+    )
+    base.update(over)
+    return EvalResult(**base)
+
+
+class TestResultCarriesMockFlag:
+    def test_evalresult_has_mock_field_defaulting_false(self):
+        assert "mock" in EvalResult.__dataclass_fields__
+        assert _bare_result().mock is False
+
+    def test_mock_engine_marks_its_result(self):
+        assert _mock_eval().mock is True
+
+    def test_mock_run_reports_no_cost(self):
+        # A run that made no API call must not report a price for it.
+        assert _mock_eval().cost_usd == 0.0
+
+
+class TestRenderersDiscloseMock:
+    def _render(self, fn, result) -> str:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            fn(result)
+        return buf.getvalue()
+
+    def test_strict_output_marks_mock(self):
+        from vulca.cli import _print_strict_result
+
+        out = self._render(_print_strict_result, _mock_eval())
+        assert MARKER in out
+
+    def test_reference_output_marks_mock(self):
+        from vulca.cli import _print_reference_result
+
+        result = _mock_eval()
+        result.eval_mode = "reference"
+        out = self._render(_print_reference_result, result)
+        assert MARKER in out
+
+    def test_real_output_is_not_marked(self):
+        # Guard against a marker that is always on, which would be just as useless.
+        from vulca.cli import _print_strict_result
+
+        real = _bare_result(cost_usd=0.0011)
+        assert MARKER not in self._render(_print_strict_result, real)
+
+
+class TestFusionDisclosesMock:
+    """Fusion compares several traditions at once; one mock result taints the table."""
+
+    def test_fusion_output_marks_mock(self):
+        import io
+        from contextlib import redirect_stdout
+        from vulca.cli import _print_fusion_result
+
+        results = [("chinese_xieyi", _mock_eval()), ("western_academic", _mock_eval())]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_fusion_result(results)
+        out = buf.getvalue()
+        assert MARKER in out
+        assert "Cost: $" not in out
+
+    def test_fusion_real_output_is_not_marked(self):
+        import io
+        from contextlib import redirect_stdout
+        from vulca.cli import _print_fusion_result
+
+        results = [("chinese_xieyi", _bare_result()), ("western_academic", _bare_result())]
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_fusion_result(results)
+        out = buf.getvalue()
+        assert MARKER not in out
+        assert "Cost: $" in out


### PR DESCRIPTION
Two defects in the evaluation output, both of the same shape: a result that is not evidence, presented in a form indistinguishable from one that is.

Found while auditing whether the CLI is fit to produce a paid pre-release audit report. Both were reproduced against the live API rather than argued from the code.

### 1. A mock run did not say it was one

`vulca evaluate --mock` printed a full score sheet — five dimension bars, a summary, and `Cost: $0.0011` — with nothing anywhere saying the numbers were synthetic and no API call had been made.

The root cause was in the type: `mock` travelled through the engine as a parameter and never reached `EvalResult`, so no renderer could tell the two apart even in principle.

### 2. A crashed run was delivered as a verdict of zero

`_vlm.score_image` catches every exception and returns a complete payload with all five dimensions at `0.0`. Everything downstream treated that as a measurement — a normal score sheet reading 0% at every level, a summary naming the "strongest" dimension, `risk_flags` empty, and **exit code 0**. The only trace was a log line, lost the moment stdout is redirected into a report, and a magic string inside `L1_rationale`.

Of four real runs against one image, one crashed this way and three returned genuine verdicts. A reader could not tell which was which.

### What changed

| | |
|---|---|
| `EvalResult` | gains `mock`, `failed`, `error` |
| `CreateResult` | gains `provider`, `mock` — `create` picks a provider by name and `mock` is one of the choices, so a run can be entirely synthetic with nothing passed |
| engine | sets all of them from the payload; a mock run reports no cost |
| renderers | strict, reference and fusion lead with a banner; `_print_fusion_result` and `_print_create_result` were extracted from their command functions to be testable at all, which is why the same defect could hide in both |
| `vulca evaluate` | exits non-zero when scoring failed |

A run that genuinely scores zero is unaffected — verified against the live API, a real 0% verdict still exits 0 and carries its rationales.

### Verification

Sixteen new tests, each confirmed to fail on unpatched code first. Two of those first failures were fixture errors in the tests themselves and were corrected so that every test fails for the reason it is testing.

Full suite compared against a clean worktree at HEAD, same three `torch`-dependent modules excluded from both sides:

| | failed |
|---|---|
| baseline | 19 |
| this branch | 15 |

No new failure. The four that differ are `test_every_layer_png_exists`, which assert generated PNGs on disk that a fresh checkout does not have.

### Known and not covered

- **inpaint** — `InpaintResult` has neither field, so `cli.py:1525` still prints a cost unconditionally.
- **`cost_usd` is an estimate, not a measurement.** `_estimate_cost(skills)` returned the same `$0.0011` for a mock run and for a real one. Printing that as `Cost:` is the same class of problem as the two fixed here, and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)