### PR TITLE
fix: report the cost that was charged, not a constant

### DIFF
--- a/src/vulca/_engine.py
+++ b/src/vulca/_engine.py
@@ -233,8 +233,16 @@ class Engine:
 
         summary = _build_summary(weighted_total, resolved_tradition, dimensions, mode)
 
-        # A mock run calls no API, so it has no cost to report.
-        cost = 0.0 if self.mock else _estimate_cost(skills or [])
+        # A mock run calls no API, so it has no cost to report. Otherwise prefer
+        # what the provider actually charged; _estimate_cost is a constant and
+        # must not be presented as a measurement.
+        measured = vlm_result.get("_cost_usd")
+        if self.mock:
+            cost, cost_is_estimate = 0.0, False
+        elif measured is not None:
+            cost, cost_is_estimate = float(measured), False
+        else:
+            cost, cost_is_estimate = _estimate_cost(skills or []), True
 
         # score_image swallows every exception and returns zeros; carry that
         # fact onto the result so callers are not handed a fabricated verdict.
@@ -261,6 +269,7 @@ class Engine:
             skills=skill_results,
             intent_confidence=intent_confidence,
             cost_usd=cost,
+            cost_is_estimate=cost_is_estimate,
             mock=self.mock,
             failed=bool(scoring_error),
             error=scoring_error,

--- a/src/vulca/_vlm.py
+++ b/src/vulca/_vlm.py
@@ -620,6 +620,15 @@ async def score_image(
             else:
                 break
 
+        # Real usage and cost, when the provider reports them. Kept separate
+        # from the static estimate so callers can tell a measurement from a
+        # placeholder.
+        measured_cost = None
+        try:
+            measured_cost = float(litellm.completion_cost(completion_response=resp))
+        except Exception:
+            measured_cost = None
+
         text = resp.choices[0].message.content.strip()
         from vulca._parse import parse_llm_json
         # Extract only the <scoring> section (strips <observation> scratchpad)
@@ -673,6 +682,8 @@ async def score_image(
             data[f"{level}_reference_technique"] = ref_techniques.get(level, "")
         # Include risk_flags so _engine.py can read it from the flat dict
         data["risk_flags"] = parsed["risk_flags"]
+        if measured_cost is not None:
+            data["_cost_usd"] = measured_cost
         # Store extra_keys and names in data so _engine.py can split core vs extra
         data["_extra_keys"] = extra_keys
         data["_extra_names"] = {e["key"]: e["name"] for e in extra_dims[:3]}

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -673,6 +673,11 @@ def _print_cost_line(result) -> None:
     """Cost and latency, or a plain statement that a mock run has neither."""
     if getattr(result, "mock", False):
         print("\n  MOCK run: no API call, no cost.")
+    elif getattr(result, "cost_is_estimate", True):
+        print(
+            f"\n  Latency: {result.latency_ms}ms | "
+            f"Est. cost: ${result.cost_usd:.4f} (fixed estimate, not measured usage)"
+        )
     else:
         print(f"\n  Latency: {result.latency_ms}ms | Cost: ${result.cost_usd:.4f}")
 

--- a/src/vulca/types.py
+++ b/src/vulca/types.py
@@ -83,6 +83,15 @@ class EvalResult:
     cost_usd: float = 0.0
     """Estimated API cost in USD."""
 
+    cost_is_estimate: bool = True
+    """True when :attr:`cost_usd` is a constant rather than measured usage.
+
+    ``_estimate_cost`` returns a fixed figure that does not depend on the call,
+    and printed the same value for a mock run and a real one. Defaulting to True
+    means a caller has to be told explicitly that a cost was measured, rather
+    than inferring it from a number that looks precise.
+    """
+
     failed: bool = False
     """True when scoring raised and the dimensions below are not measurements.
 

--- a/tests/test_mock_disclosure.py
+++ b/tests/test_mock_disclosure.py
@@ -100,7 +100,7 @@ class TestFusionDisclosesMock:
             _print_fusion_result(results)
         out = buf.getvalue()
         assert MARKER in out
-        assert "Cost: $" not in out
+        assert "cost: $" not in out.lower()
 
     def test_fusion_real_output_is_not_marked(self):
         import io
@@ -113,7 +113,7 @@ class TestFusionDisclosesMock:
             _print_fusion_result(results)
         out = buf.getvalue()
         assert MARKER not in out
-        assert "Cost: $" in out
+        assert "cost: $" in out.lower()
 
 
 # -- Create path -----------------------------------------------------------
@@ -156,12 +156,12 @@ class TestCreateRendererDisclosesMock:
     def test_mock_provider_is_disclosed(self):
         out = self._render(_bare_create(mock=True, provider="mock", cost_usd=0.0))
         assert MARKER in out
-        assert "Cost: $" not in out
+        assert "cost: $" not in out.lower()
 
     def test_real_provider_is_not_marked(self):
         out = self._render(_bare_create(provider="nb2", cost_usd=0.0042))
         assert MARKER not in out
-        assert "Cost: $" in out
+        assert "cost: $" in out.lower()
 
 
 # -- Failed scoring --------------------------------------------------------
@@ -241,3 +241,59 @@ class TestExitCode:
 
         assert _exit_code_for(_bare_result(failed=True, error="boom")) != 0
         assert _exit_code_for(_bare_result()) == 0
+
+
+# -- Cost provenance -------------------------------------------------------
+#
+# `_estimate_cost` returns 0.001 + 0.0001 + 0.0002 * len(skills): a constant.
+# It printed the same $0.0011 for a mock run and for a real one against the
+# live API. Labelling a constant as "Cost" is the same failure as labelling a
+# mock score as a measurement.
+
+
+class TestCostProvenance:
+    def test_result_records_whether_cost_was_measured(self):
+        assert "cost_is_estimate" in EvalResult.__dataclass_fields__
+        # Anything not explicitly measured is an estimate.
+        assert _bare_result().cost_is_estimate is True
+
+    def test_estimated_cost_is_labelled_as_such(self):
+        import io
+        from contextlib import redirect_stdout
+        from vulca.cli import _print_strict_result
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_strict_result(_bare_result(cost_usd=0.0011, cost_is_estimate=True))
+        out = buf.getvalue()
+        assert "Est. cost" in out
+        assert "Cost: $" not in out
+
+    def test_measured_cost_is_not_called_an_estimate(self):
+        import io
+        from contextlib import redirect_stdout
+        from vulca.cli import _print_strict_result
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            _print_strict_result(_bare_result(cost_usd=0.0042, cost_is_estimate=False))
+        out = buf.getvalue()
+        assert "Cost: $" in out
+        assert "Est. cost" not in out
+
+    def test_engine_prefers_a_measured_cost_over_the_estimate(self, monkeypatch):
+        import vulca._engine as eng
+
+        payload = {f"L{i}": 0.8 for i in range(1, 6)}
+        payload["_extra_keys"] = []
+        payload["_cost_usd"] = 0.0037
+
+        async def _scored(**kwargs):
+            return payload
+
+        monkeypatch.setattr(eng, "score_image", _scored)
+        monkeypatch.setattr(eng, "load_image_base64", lambda *a, **k: _immediate(("", "image/png")))
+
+        result = asyncio.run(eng.Engine(api_key="k").run("x.png", tradition="chinese_xieyi"))
+        assert result.cost_usd == 0.0037
+        assert result.cost_is_estimate is False


### PR DESCRIPTION
`_estimate_cost` returns `0.001 + 0.0001 + 0.0002 * len(skills)`. With no skills that is **$0.0011 for every call ever made**, and the CLI printed it under the label `Cost:`.

It was noticed because a mock run and a real one reported the same figure.

### The data was already there

litellm's response carries usage, and the code read it — only to write it into an optional debug dump behind `VULCA_VLM_DEBUG_DUMP`. `score_image` now also asks litellm for the completion cost and returns it; the engine prefers that over the estimate and the result records which of the two it holds.

### How wrong the constant was

Measured against the live API on the same image:

| | cost |
|---|---|
| the constant | $0.0011 |
| measured, run 1 | $0.0053 |
| measured, run 2 | $0.0115 |

Five to ten times understated. Anyone quoting API spend from that number was out by an order of magnitude.

### Behaviour

| state | output |
|---|---|
| measured | `Cost: $0.0053` |
| estimated | `Est. cost: $0.0011 (fixed estimate, not measured usage)` |
| mock | `MOCK run: no API call, no cost.` |

`cost_is_estimate` defaults to `True`, so a caller has to be told that a cost was measured rather than infer it from a number that looks precise.

### Verification

Four new tests, each confirmed to fail on unpatched code first. Two earlier assertions pinned the literal string `Cost: $` and were loosened — that label is exactly what this change makes conditional.

Full suite against a clean worktree at HEAD, same three `torch`-dependent modules excluded from both sides: **19 failed before, 15 after, no new failure**.

### Not covered

inpaint. `InpaintResult` has none of `failed`, `mock`, or `cost_is_estimate`, so `cli.py` still prints an unconditional cost for that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)